### PR TITLE
Fix DbFactory

### DIFF
--- a/src/Database/DbFactory.php
+++ b/src/Database/DbFactory.php
@@ -37,7 +37,7 @@ class DbFactory
      */
     public function getInstance()
     {
-        $className = '\Porter\Database\\' . $this->extension . 'Db';
+        $className = '\Porter\Database\\' . ucase($this->extension) . 'DB';
         if (!class_exists($className)) {
             trigger_error($this->extension . ' extension not found.');
         }


### PR DESCRIPTION
The filename is `PdoDB.php` so we need to handle that, and use an uppercase 'DB' when calling the className. Alternatively, the PdoDB file could be renamed, but I'm sure which you would prefer.