### PR TITLE
fix: waterhole isnt defined as target

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The only multi-platform community migration tool. Free your forum!
 Currently [exports](https://nitroporter.org/targets) to: 
 * Flarum
 * Vanilla
+* Waterhole
 
 Currently imports from:
 * Flarum


### PR DESCRIPTION
Seems as part of #24 the readme wasn't updated with this new information.