### PR TITLE
Draft: Add new docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: Deploy Docs
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - run: npm ci
+      - name: Build
+        run: npm run docs:build
+      - uses: actions/configure-pages@v2
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/.vitepress/dist
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ vendor
 build/current
 .phpunit.cache
 seed_database.php
+node_modules
+docs/.vitepress/dist
+docs/.vitepress/cache

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,42 @@
+import { defineConfig } from 'vitepress';
+
+// https://vitepress.dev/reference/site-config
+export default defineConfig({
+    title: 'Nitro Porter',
+    description: 'Data migrations for communities',
+
+    themeConfig: {
+        // https://vitepress.dev/reference/default-theme-config
+        nav: [
+            { text: 'Home', link: '/' },
+        ],
+
+        sidebar: [
+            {
+                text: 'Introduction',
+                items: [
+                    { text: 'Overview', link: '/' },
+                    { text: 'Migration Planning', link: '/migrations' },
+                ],
+            },
+            {
+                text: 'Migrations',
+                items: [
+                    { text: 'Quick Start', link: '/usage' },
+                    { text: 'Supported Sources', link: '/sources' },
+                    { text: 'Supported Targets', link: '/targets' },
+                ],
+            },
+            {
+                text: 'Development',
+                items: [
+                    { text: 'Developer Guide', link: '/develop' },
+                ],
+            },
+        ],
+
+        socialLinks: [
+            { icon: 'github', link: 'https://github.com/linc/nitro-porter' },
+        ],
+    }
+});

--- a/docs/.vitepress/theme/index.mts
+++ b/docs/.vitepress/theme/index.mts
@@ -1,0 +1,4 @@
+import DefaultTheme from 'vitepress/theme';
+import './custom.css';
+
+export default DefaultTheme;

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,0 +1,110 @@
+# Developer Guide
+
+Nitro Porter works in this order:
+
+1. The **Source** package translates the data to the intermediary "porter format" (see below). These are new database tables with the prefix `PORT_`.
+2. The **Target** package translates the data to the final platform format. These can be existing tables from an installation, or it will create them new using the information provided.
+3. If a **Postscript** file with the same name as the Target exists, it runs last. This is for doing calculations that require the data to have been fully transferred already, for example generating data that wasn't ever in the Source.
+
+The `ExportModel` is a utility class that gets passed between every step in the process. It's abbreviated as `$ex` throughout the code.
+
+Use its `comment()` method for logging. Open `porter.log` in your favorite log reader for realtime feedback.
+
+## Porter Format
+
+Nitro Porter uses a "porter format" roughly analogous to the database design of Vanilla Forums. 
+That means all sources translate to Vanilla, and all targets translate from Vanilla. Doing this alleviates multiple challenges.
+
+First, imagine 50 sources and 50 targets. Direct migrations would create exponential complexity (50:50 = 2500 possible paths).
+By using a dedicated intermediary, complexity is significantly constrained (50:1 and 1:50, so that only 100 paths are possible).
+
+Second, many forum database designs are difficult to interpret and/or very strict in their data structure. 
+Vanilla's is fairly sensible and serves as a good reference. It was also designed for easy import.
+
+Third, Nitro Porter's origin is as a Vanilla migration tool, so it preserves backwards compatibility for the original sources.
+
+### Considerations regarding Porter Format
+
+One common issue with this Porter Format is that the original post's body is attached directly to the discussion record.
+A majority of forums instead associate a generic post/comment record as the "first", and the discussion record contains only the title. 
+Nitro Porter uses the `getDiscussionBodyMode()` method to skip the overhead of doing this conversion if both the source and target use this alternative structure.
+
+Private messages in Vanilla function as a discussion with an allowlist of participants. 
+There is no consideration of when a user was added to a private message chain. It does not support PM organization in any way.
+
+
+## Add a new Source
+
+**New sources will be automatically detected at runtime and added as options.**
+
+1. Copy and rename `src/Source/Example.php`.
+2. Edit the `SUPPORTED` data array, following the inline comments.
+3. The basic types of data are stubbed out, one per method. Follow the inline docs.
+
+Source packages are invoked by their `run()` method. It must call any methods you add in the order you want.
+
+### Maps and filters
+
+Use a `$map` array to directly translate a column name in one database to another. Need the data transformed? You can use a function. Pass an array like `['Column' => 'Name', 'Filter' => 'HTMLDecoder']` and the `Name` column's value will be passed to the function `HTMLDecoder()` (along with the rest of the data in the row) for manipulation and the return value will be stored instead of the original. Use the `src/Functions/filter.php` for adding new filters.
+
+### Using export()
+
+The `ExportModel::export()` call is what does the data transfer. The `$query` parameter must at least select all the columns in the `$map` array for it to work. Use the table prefix `:_` for it to be dynamically replaced per the user's input.
+
+### Requiring tables and columns
+
+You can use the `$sourceTables` property to require certain tables and columns in the source database, but it's optional.
+
+## Add a new Target
+
+1. Copy and rename `src/Target/Example.php`.
+2. Edit the `SUPPORTED` data array, following the inline comments.
+3. The basic types of data are stubbed out, one per method. Follow the inline docs.
+
+Target packages first have their `validate()` method called, then their `run()` method.
+
+To confirm an optional data type exists before importing it, use `targetExists()` on the `ExportModel`.
+
+### Verify source support for each feature
+
+It's not safe to assume every `PORT_` table will be present because not all source packages provide all types of feature data.
+
+These tables should always be present: `PORT_User`, `PORT_Discussion`, `PORT_Comment`, and `PORT_Category`.
+
+For all others, check if the table exists. Example:
+
+```php
+        // Verify support.
+        if (!$ex->targetExists('PORT_FeatureName')) {
+            $ex->comment('Skipping import: FeatureName (Source lacks support)');
+            return;
+        }
+```
+
+Generally tables come in bundles. For instance, there's little use for `PORT_Role` if `PORT_UserRole` is not also present. Checking for one is usually sufficient.
+
+### Using import()
+
+The `import()` method works a bit more cleanly than the `export()` method. It takes a map array, but also accepts a built SQL statement rather than a query string. It requires defining the target database table structure, and separates filters into their own array for clarity. Use `$ex->dbImport()` to build the SQL statement.
+
+If a column isn't present in the structure passed to `import()`, it will be ignored entirely.
+
+### Using a Postscript
+
+Simply add a new PHP class to the `src/Postscript` folder with the same name as the Target and a method named `run()`. It will automatically run after the import. Its `storage` property will get set with the database connection automatically.
+
+
+## Working with database connections
+
+Nitro Porter uses the [Laravel Illuminate](https://github.com/illuminate/database) database driver. Refer to its [documentation](https://laravel.com/docs/9.x) for help.
+
+While Nitro Porter reuses an existing database connection wherever possible, it defaults to using an unbuffered query for speed, and it will often be advisable to use the driver's `cursor()` method to stream the results.
+
+You need a second, separate database connection to do other queries while unbuffered results are streaming. The streaming connection is effectively mid-query. While this rarely comes up in **Source** packages since they are simply dumping information and the **Target** package usually abstracts away much of this work, it can get tricky when complex **Postscript** operations are necessary. Refer to the `Flarum` Postscript for examples.
+
+
+## Non-MySQL help
+
+### MSSQL conversions
+
+If you need to migrate from MSSQL with a `.bak` file (e.g. from AspPlayground) and you're working on an M1 Macbook Pro, [this guide will help](https://lincolnwebs.com/mssql-macos/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,40 @@
+# Nitro Porter
+
+**Nitro Porter is a multi-platform community migration tool.**
+
+Nitro Porter supports over 30 **[sources](/sources)** (the software you're leaving) and 3 **[targets](/targets)** (the software you're moving to).
+
+All data sources & targets support users, user roles, discussions, posts, and basic taxonomy ("categories" or "subforums" or "tags" depending on the platform).
+Beyond that, each supports different types of data depending on feature availability, extension choice, and maturity of the source/target package.
+These include things like badges, reactions, bookmarks, and polls.
+
+Both the source and target must support a data type for it to transfer.
+
+Nitro Porter never transfers permissions. It's not safe to do so automatically due to variations in how platforms implement them.
+
+## Project goals & motivation
+
+Community software has high lock-in due to the difficulty of preserving history through a data migration.
+
+Community history is vitally important, and being able to change software is important for the health of the community software ecosystem.
+
+Nitro Porter exists because your community deserves both the best tools available and the continuity of its unique history.
+It uses the GNU Public License 2.0 to ensure it remains freely available to anyone who needs it.
+
+This tool is designed for ease of extensibility to allow anyone with basic programming skills to add a source or target.
+Any generally available forum software (commercial or free) may be added as a source or target.
+It does not include bespoke or custom forum software, but is designed to allow individuals to create such support easily for their private use.
+
+## History
+
+Nitro Porter was created in 2010 at Vanilla Forums, Inc. as "Vanilla Porter". 
+The first several versions only exported to the Vanilla flat file format, which then Vanilla core would import and do final data manipulations.
+Lincoln built the first source package for vBulletin, and several other engineers (both internal to Vanilla and OSS contributors) built additional packages.
+
+Originally designed as a single-file "lifeboat" for rescuing forum data on older webservers, it morphed into an efficient CLI-based export tool.
+Over a decade, export ("source") support was added for many forum packages, eventually exceeding thirty platforms.
+
+By late 2019, Vanilla had ceased creating packaged open source releases and Vanilla Porter was receiving only minimal updates.
+
+In September 2021, Lincoln forked the GPL2 project as Nitro Porter and rebuilt it into a general-purpose migration pipeline.
+It continues to use Vanilla's database schema as an intermediary format to allow backwards compatibility with the source packages already created.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,40 @@
+# Community Migrations
+
+Running a seamless community platform is quite challenging. Here's some suggestions for making yours successful.
+
+## Explain the migration to your community
+
+Weeks or months before your migration, explain the motivations and what value you think the community will get from the migration. Many folks don't like change, so giving them time to process, ask questions, and maybe even vent a bit are a normal part of the process. You might also learn some things about how your community is using the current software so you can adapt your plans.
+
+## Get power users to test the new software
+
+Days or weeks before your migration, invite "power users" of your community to try out a staged copy of it. Solicit feedback and see if there are things you can do to address concerns. 
+
+## Do a test run
+
+Never "just do" a migration. They're very, very complex. Take some dedicated time to do a test run and then ideally have multiple folks looking for issues.
+
+## Set up redirects for everything possible
+
+Creating 301 redirects between old and new content (so that old bookmarks and links still function as expected) are a huge boon to both your everyday users and maintaining your position in search results.
+
+## Move files in advance if you can
+
+If your community uploads images or files, these are typically many times the storage space of the database (content) and will take much longer to transfer between servers. Don't save it for the end. If you can iteratively move files ahead of time and then only move files uploaded in the last few days at the time of migration, that's ideal. If that's too complex, just move them all at once as soon as you put the site in maintenance mode for the final migration.
+
+## Minimize downtime
+
+Try to restrict downtime to a day or less. If possible, use a maintenance mode that simply prevents new content from being added instead of completely blocking access while the migration is in progress.
+
+## Avoid complexity (like deltas)
+
+If you're moving a database between systems, do it all at once. Don't try to do most of it sooner and then only recent content for the final migration. It's worlds more complex.
+
+## Give folks a channel for feedback
+
+After the migration, continue collecting feedback for 4-6 weeks. Folks will discover new issues and this is a prime opportunity to hear about how the new software is working for them and how things could be improved.
+
+## Don't panic, but address what you can
+
+Don't take all the feedback and bury it! Be selective, but do improve things where you can easily do so. It will strengthen your community.
+

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,0 +1,768 @@
+# Supported Sources
+
+<table class="feature-table">
+    <thead>
+        <tr>
+            <th></th>
+            <th>Users</th>
+            <th>Categories</th>
+            <th>Discussions</th>
+            <th>Comments</th>
+            <th>Roles</th>
+            <th>Passwords</th>
+            <th>Private Messages</th>
+            <th>Attachments</th>
+            <th>Bookmarks</th>
+            <th>Avatars</th>
+            <th>Signatures</th>
+            <th>Polls</th>
+            <th>Tags</th>
+            <th>Reactions</th>
+            <th>Badges</th>
+            <th>User Notes</th>
+            <th>Ranks</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Advanced Forum 7.x-2.*</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>answerhub</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>ASP Playground</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>bbPress 1</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>bbPress 2</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>CodoForum</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Drupal 6</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Drupal 7</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>esoTalk</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Expression Engine Discussion Forum</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Flarum</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>FluxBB 1</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>FuseTalk</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>IP.Board 3</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>jforum</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Joomla Kunena</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>.mbox files</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>MODX Discuss Extension</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>MVC</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>MyBB</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>NodeBB 0.*</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>phpBB 2</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>phpBB 3</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+        </tr>
+        <tr>
+            <td>PunBB 1</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Questions2Answers</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>SimplePress 1</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Simple Machines 1</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Simple Machines 2</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Toast</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>User Voice</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Vanilla 1</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Vanilla 2+</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+        </tr>
+        <tr>
+            <td>vBulletin 3 & 4</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+        </tr>
+        <tr>
+            <td>vBulletin 5 Connect</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Web Wiz Forums</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Xenforo</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>YAF.NET</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -1,0 +1,68 @@
+# Supported Targets
+
+<table class="feature-table">
+    <thead>
+        <tr>
+            <th></th>
+            <th>Users</th>
+            <th>Categories</th>
+            <th>Discussions</th>
+            <th>Comments</th>
+            <th>Roles</th>
+            <th>Passwords</th>
+            <th>Private Messages</th>
+            <th>Attachments</th>
+            <th>Bookmarks</th>
+            <th>Avatars</th>
+            <th>Signatures</th>
+            <th>Polls</th>
+            <th>Tags</th>
+            <th>Reactions</th>
+            <th>Badges</th>
+            <th>User Notes</th>
+            <th>Ranks</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Flarum</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+        <tr>
+            <td>Waterhole</td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-yes">✓</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+            <td><span class="feature-no">✗</span></td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,79 @@
+# Quick Start
+
+## Requirements
+
+* PHP 8.0+
+* PHP's PDO driver for your data sources (probably MySQL or PostgreSQL)
+* 256MB of memory allocated to PHP
+
+::: tip
+Nitro Porter will set PHP's memory limit to 256MB. If it's unable to do so, it may suffer performance issues or generate errors. For small forums, you may be able to safely reconfigure it to 128MB or lower.
+:::
+
+## Installation
+
+Install Nitro Porter as a global [Composer](https://getcomposer.org) package:
+
+```bash
+composer global require linc/nitro-porter
+```
+
+This will make the `porter` command-line utility available system-wide.
+
+## Configuration
+
+Set up a new Porter project by running the `init` command:
+
+```bash
+porter init
+```
+
+This will create a new `porter.config.php` file in the current directory. Open this file and configure the database connections for your source database and your target database.
+
+```php
+return [
+    'connections' => [
+        'source' => [
+            'type' => 'database',
+            'driver' => 'mysql',
+            'database' => 'database',
+            'username' => 'root',
+            'password' => 'password',
+            'charset' => 'utf8',
+            'collation' => 'utf8_unicode_ci',
+            'prefix' => '',
+            'options' => [
+                PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false,
+            ],
+        ],
+        
+        'target' => [
+            'type' => 'database',
+            'driver' => 'mysql',
+            'database' => 'database',
+            'username' => 'root',
+            'password' => 'password',
+            'charset' => 'utf8',
+            'collation' => 'utf8_unicode_ci',
+            'prefix' => '',
+            'options' => [
+                PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false,
+            ],
+        ],
+    ],
+];
+```
+
+## Running a Migration
+
+To run a migration, use the `run` command:
+
+```bash
+porter run
+```
+
+You will be asked to select the source and target platforms. Porter will then run the migration and output its progress to the console.
+
+## Cleaning Up
+
+Porter uses `PORT_` as the prefix for its intermediary work storage. You can safely delete the `PORT_` tables after the migration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2042 @@
+{
+  "name": "nitro-porter",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "vitepress": "^1.0.0-rc.32"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+        "@algolia/autocomplete-shared": "1.9.3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/cache-browser-local-storage": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.0.tgz",
+      "integrity": "sha512-uZ1uZMLDZb4qODLfTSNHxSi4fH9RdrQf7DXEzW01dS8XK7QFtFh29N5NGKa9S+Yudf1vUMIF+/RiL4i/J0pWlQ==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.22.0"
+      }
+    },
+    "node_modules/@algolia/cache-common": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.0.tgz",
+      "integrity": "sha512-TPwUMlIGPN16eW67qamNQUmxNiGHg/WBqWcrOoCddhqNTqGDPVqmgfaM85LPbt24t3r1z0zEz/tdsmuq3Q6oaA==",
+      "dev": true
+    },
+    "node_modules/@algolia/cache-in-memory": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.0.tgz",
+      "integrity": "sha512-kf4Cio9NpPjzp1+uXQgL4jsMDeck7MP89BYThSvXSjf2A6qV/0KeqQf90TL2ECS02ovLOBXkk98P7qVarM+zGA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.22.0"
+      }
+    },
+    "node_modules/@algolia/client-account": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.0.tgz",
+      "integrity": "sha512-Bjb5UXpWmJT+yGWiqAJL0prkENyEZTBzdC+N1vBuHjwIJcjLMjPB6j1hNBRbT12Lmwi55uzqeMIKS69w+0aPzA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.22.0",
+        "@algolia/client-search": "4.22.0",
+        "@algolia/transporter": "4.22.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.0.tgz",
+      "integrity": "sha512-os2K+kHUcwwRa4ArFl5p/3YbF9lN3TLOPkbXXXxOvDpqFh62n9IRZuzfxpHxMPKAQS3Et1s0BkKavnNP02E9Hg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.22.0",
+        "@algolia/client-search": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.0.tgz",
+      "integrity": "sha512-BlbkF4qXVWuwTmYxVWvqtatCR3lzXwxx628p1wj1Q7QP2+LsTmGt1DiUYRuy9jG7iMsnlExby6kRMOOlbhv2Ag==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.0.tgz",
+      "integrity": "sha512-pEOftCxeBdG5pL97WngOBi9w5Vxr5KCV2j2D+xMVZH8MuU/JX7CglDSDDb0ffQWYqcUN+40Ry+xtXEYaGXTGow==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.0.tgz",
+      "integrity": "sha512-bn4qQiIdRPBGCwsNuuqB8rdHhGKKWIij9OqidM1UkQxnSG8yzxHdb7CujM30pvp5EnV7jTqDZRbxacbjYVW20Q==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/client-common": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
+      }
+    },
+    "node_modules/@algolia/logger-common": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.0.tgz",
+      "integrity": "sha512-HMUQTID0ucxNCXs5d1eBJ5q/HuKg8rFVE/vOiLaM4Abfeq1YnTtGV3+rFEhOPWhRQxNDd+YHa4q864IMc0zHpQ==",
+      "dev": true
+    },
+    "node_modules/@algolia/logger-console": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.0.tgz",
+      "integrity": "sha512-7JKb6hgcY64H7CRm3u6DRAiiEVXMvCJV5gRE672QFOUgDxo4aiDpfU61g6Uzy8NKjlEzHMmgG4e2fklELmPXhQ==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/logger-common": "4.22.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.0.tgz",
+      "integrity": "sha512-BHfv1h7P9/SyvcDJDaRuIwDu2yrDLlXlYmjvaLZTtPw6Ok/ZVhBR55JqW832XN/Fsl6k3LjdkYHHR7xnsa5Wvg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.22.0"
+      }
+    },
+    "node_modules/@algolia/requester-common": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.0.tgz",
+      "integrity": "sha512-Y9cEH/cKjIIZgzvI1aI0ARdtR/xRrOR13g5psCxkdhpgRN0Vcorx+zePhmAa4jdQNqexpxtkUdcKYugBzMZJgQ==",
+      "dev": true
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.0.tgz",
+      "integrity": "sha512-8xHoGpxVhz3u2MYIieHIB6MsnX+vfd5PS4REgglejJ6lPigftRhTdBCToe6zbwq4p0anZXjjPDvNWMlgK2+xYA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/requester-common": "4.22.0"
+      }
+    },
+    "node_modules/@algolia/transporter": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.0.tgz",
+      "integrity": "sha512-ieO1k8x2o77GNvOoC+vAkFKppydQSVfbjM3YrSjLmgywiBejPTvU1R1nEvG59JIIUvtSLrZsLGPkd6vL14zopA==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-common": "4.22.0",
+        "@algolia/logger-common": "4.22.0",
+        "@algolia/requester-common": "4.22.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
+      "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==",
+      "dev": true
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.2.tgz",
+      "integrity": "sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==",
+      "dev": true,
+      "dependencies": {
+        "@docsearch/react": "3.5.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
+      "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.9.3",
+        "@algolia/autocomplete-preset-algolia": "1.9.3",
+        "@docsearch/css": "3.5.2",
+        "algoliasearch": "^4.19.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.10.tgz",
+      "integrity": "sha512-Q+mk96KJ+FZ30h9fsJl+67IjNJm3x2eX+GBWGmocAKgzp27cowCOOqSdscX80s0SpdFXZnIv/+1xD1EctFx96Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.10.tgz",
+      "integrity": "sha512-7W0bK7qfkw1fc2viBfrtAEkDKHatYfHzr/jKAHNr9BvkYDXPcC6bodtm8AyLJNNuqClLNaeTLuwURt4PRT9d7w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.10.tgz",
+      "integrity": "sha512-1X4CClKhDgC3by7k8aOWZeBXQX8dHT5QAMCAQDArCLaYfkppoARvh0fit3X2Qs+MXDngKcHv6XXyQCpY0hkK1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.10.tgz",
+      "integrity": "sha512-O/nO/g+/7NlitUxETkUv/IvADKuZXyH4BHf/g/7laqKC4i/7whLpB0gvpPc2zpF0q9Q6FXS3TS75QHac9MvVWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.10.tgz",
+      "integrity": "sha512-YSRRs2zOpwypck+6GL3wGXx2gNP7DXzetmo5pHXLrY/VIMsS59yKfjPizQ4lLt5vEI80M41gjm2BxrGZ5U+VMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.10.tgz",
+      "integrity": "sha512-alfGtT+IEICKtNE54hbvPg13xGBe4GkVxyGWtzr+yHO7HIiRJppPDhOKq3zstTcVf8msXb/t4eavW3jCDpMSmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.10.tgz",
+      "integrity": "sha512-dMtk1wc7FSH8CCkE854GyGuNKCewlh+7heYP/sclpOG6Cectzk14qdUIY5CrKDbkA/OczXq9WesqnPl09mj5dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.10.tgz",
+      "integrity": "sha512-G5UPPspryHu1T3uX8WiOEUa6q6OlQh6gNl4CO4Iw5PS+Kg5bVggVFehzXBJY6X6RSOMS8iXDv2330VzaObm4Ag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.10.tgz",
+      "integrity": "sha512-j6gUW5aAaPgD416Hk9FHxn27On28H4eVI9rJ4az7oCGTFW48+LcgNDBN+9f8rKZz7EEowo889CPKyeaD0iw9Kg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.10.tgz",
+      "integrity": "sha512-QxaouHWZ+2KWEj7cGJmvTIHVALfhpGxo3WLmlYfJ+dA5fJB6lDEIg+oe/0//FuyVHuS3l79/wyBxbHr0NgtxJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.10.tgz",
+      "integrity": "sha512-4ub1YwXxYjj9h1UIZs2hYbnTZBtenPw5NfXCRgEkGb0b6OJ2gpkMvDqRDYIDRjRdWSe/TBiZltm3Y3Q8SN1xNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.10.tgz",
+      "integrity": "sha512-lo3I9k+mbEKoxtoIbM0yC/MZ1i2wM0cIeOejlVdZ3D86LAcFXFRdeuZmh91QJvUTW51bOK5W2BznGNIl4+mDaA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.10.tgz",
+      "integrity": "sha512-J4gH3zhHNbdZN0Bcr1QUGVNkHTdpijgx5VMxeetSk6ntdt+vR1DqGmHxQYHRmNb77tP6GVvD+K0NyO4xjd7y4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.10.tgz",
+      "integrity": "sha512-tgT/7u+QhV6ge8wFMzaklOY7KqiyitgT1AUHMApau32ZlvTB/+efeCtMk4eXS+uEymYK249JsoiklZN64xt6oQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.10.tgz",
+      "integrity": "sha512-0f/spw0PfBMZBNqtKe5FLzBDGo0SKZKvMl5PHYQr3+eiSscfJ96XEknCe+JoOayybWUFQbcJTrk946i3j9uYZA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.10.tgz",
+      "integrity": "sha512-pZFe0OeskMHzHa9U38g+z8Yx5FNCLFtUnJtQMpwhS+r4S566aK2ci3t4NCP4tjt6d5j5uo4h7tExZMjeKoehAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.10.tgz",
+      "integrity": "sha512-SpYNEqg/6pZYoc+1zLCjVOYvxfZVZj6w0KROZ3Fje/QrM3nfvT2llI+wmKSrWuX6wmZeTapbarvuNNK/qepSgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.10.tgz",
+      "integrity": "sha512-ACbZ0vXy9zksNArWlk2c38NdKg25+L9pr/mVaj9SUq6lHZu/35nx2xnQVRGLrC1KKQqJKRIB0q8GspiHI3J80Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.10.tgz",
+      "integrity": "sha512-PxcgvjdSjtgPMiPQrM3pwSaG4kGphP+bLSb+cihuP0LYdZv1epbAIecHVl5sD3npkfYBZ0ZnOjR878I7MdJDFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.10.tgz",
+      "integrity": "sha512-ZkIOtrRL8SEJjr+VHjmW0znkPs+oJXhlJbNwfI37rvgeMtk3sxOQevXPXjmAPZPigVTncvFqLMd+uV0IBSEzqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.10.tgz",
+      "integrity": "sha512-+Sa4oTDbpBfGpl3Hn3XiUe4f8TU2JF7aX8cOfqFYMMjXp6ma6NJDztl5FDG8Ezx0OjwGikIHw+iA54YLDNNVfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.10.tgz",
+      "integrity": "sha512-EOGVLK1oWMBXgfttJdPHDTiivYSjX6jDNaATeNOaCOFEVcfMjtbx7WVQwPSE1eIfCp/CaSF2nSrDtzc4I9f8TQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.10.tgz",
+      "integrity": "sha512-whqLG6Sc70AbU73fFYvuYzaE4MNMBIlR1Y/IrUeOXFrWHxBEjjbZaQ3IXIQS8wJdAzue2GwYZCjOrgrU1oUHoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.1.tgz",
+      "integrity": "sha512-6vMdBZqtq1dVQ4CWdhFwhKZL6E4L1dV6jUjuBvsavvNJSppzi6dLBbuV+3+IyUREaj9ZFvQefnQm28v4OCXlig==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.1.tgz",
+      "integrity": "sha512-Jto9Fl3YQ9OLsTDWtLFPtaIMSL2kwGyGoVCmPC8Gxvym9TCZm4Sie+cVeblPO66YZsYH8MhBKDMGZ2NDxuk/XQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.1.tgz",
+      "integrity": "sha512-LtYcLNM+bhsaKAIGwVkh5IOWhaZhjTfNOkGzGqdHvhiCUVuJDalvDxEdSnhFzAn+g23wgsycmZk1vbnaibZwwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.1.tgz",
+      "integrity": "sha512-KyP/byeXu9V+etKO6Lw3E4tW4QdcnzDG/ake031mg42lob5tN+5qfr+lkcT/SGZaH2PdW4Z1NX9GHEkZ8xV7og==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.1.tgz",
+      "integrity": "sha512-Yqz/Doumf3QTKplwGNrCHe/B2p9xqDghBZSlAY0/hU6ikuDVQuOUIpDP/YcmoT+447tsZTmirmjgG3znvSCR0Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.1.tgz",
+      "integrity": "sha512-u3XkZVvxcvlAOlQJ3UsD1rFvLWqu4Ef/Ggl40WAVCuogf4S1nJPHh5RTgqYFpCOvuGJ7H5yGHabjFKEZGExk5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.1.tgz",
+      "integrity": "sha512-0XSYN/rfWShW+i+qjZ0phc6vZ7UWI8XWNz4E/l+6edFt+FxoEghrJHjX1EY/kcUGCnZzYYRCl31SNdfOi450Aw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.1.tgz",
+      "integrity": "sha512-LmYIO65oZVfFt9t6cpYkbC4d5lKHLYv5B4CSHRpnANq0VZUQXGcCPXHzbCXCz4RQnx7jvlYB1ISVNCE/omz5cw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.1.tgz",
+      "integrity": "sha512-kr8rEPQ6ns/Lmr/hiw8sEVj9aa07gh1/tQF2Y5HrNCCEPiCBGnBUt9tVusrcBBiJfIt1yNaXN6r1CCmpbFEDpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.1.tgz",
+      "integrity": "sha512-t4QSR7gN+OEZLG0MiCgPqMWZGwmeHhsM4AkegJ0Kiy6TnJ9vZ8dEIwHw1LcZKhbHxTY32hp9eVCMdR3/I8MGRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.1.tgz",
+      "integrity": "sha512-7XI4ZCBN34cb+BH557FJPmh0kmNz2c25SCQeT9OiFWEgf8+dL6ZwJ8f9RnUIit+j01u07Yvrsuu1rZGxJCc51g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.1.tgz",
+      "integrity": "sha512-yE5c2j1lSWOH5jp+Q0qNL3Mdhr8WuqCNVjc6BxbVfS5cAS6zRmdiw7ktb8GNpDCEUJphILY6KACoFoRtKoqNQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.1.tgz",
+      "integrity": "sha512-PyJsSsafjmIhVgaI1Zdj7m8BB8mMckFah/xbpplObyHfiXzKcI5UOUXRyOdHW7nz4DpMCuzLnF7v5IWHenCwYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "dev": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
+      "integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
+      "dev": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+      "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
+      "dev": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==",
+      "dev": true
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+      "dev": true
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.6.0.tgz",
+      "integrity": "sha512-XHuyFdAikWRmHuAd89FOyUGIjrBU5KlxJtyi2hVeR9ySGFxQwE0bl5xAQju/ArMq5azdBivY4d+D2yPKwoYWUg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.0.0 || ^5.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.13.tgz",
+      "integrity": "sha512-bwi9HShGu7uaZLOErZgsH2+ojsEdsjerbf2cMXPwmvcgZfVPZ2BVZzCVnwZBxTAYd6Mzbmf6izcUNDkWnBBQ6A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/shared": "3.3.13",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.13.tgz",
+      "integrity": "sha512-EYRDpbLadGtNL0Gph+HoKiYqXLqZ0xSSpR5Dvnu/Ep7ggaCbjRDIus1MMxTS2Qm0koXED4xSlvTZaTnI8cYAsw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.3.13",
+        "@vue/shared": "3.3.13"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.13.tgz",
+      "integrity": "sha512-DQVmHEy/EKIgggvnGRLx21hSqnr1smUS9Aq8tfxiiot8UR0/pXKHN9k78/qQ7etyQTFj5em5nruODON7dBeumw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.13",
+        "@vue/compiler-dom": "3.3.13",
+        "@vue/compiler-ssr": "3.3.13",
+        "@vue/reactivity-transform": "3.3.13",
+        "@vue/shared": "3.3.13",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.32",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.13.tgz",
+      "integrity": "sha512-d/P3bCeUGmkJNS1QUZSAvoCIW4fkOKK3l2deE7zrp0ypJEy+En2AcypIkqvcFQOcw3F0zt2VfMvNsA9JmExTaw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.13",
+        "@vue/shared": "3.3.13"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.1.tgz",
+      "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==",
+      "dev": true
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.13.tgz",
+      "integrity": "sha512-fjzCxceMahHhi4AxUBzQqqVhuA21RJ0COaWTbIBl1PruGW1CeY97louZzLi4smpYx+CHfFPPU/CS8NybbGvPKQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "3.3.13"
+      }
+    },
+    "node_modules/@vue/reactivity-transform": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.13.tgz",
+      "integrity": "sha512-oWnydGH0bBauhXvh5KXUy61xr9gKaMbtsMHk40IK9M4gMuKPJ342tKFarY0eQ6jef8906m35q37wwA8DMZOm5Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.23.5",
+        "@vue/compiler-core": "3.3.13",
+        "@vue/shared": "3.3.13",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.5"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.13.tgz",
+      "integrity": "sha512-1TzA5TvGuh2zUwMJgdfvrBABWZ7y8kBwBhm7BXk8rvdx2SsgcGfz2ruv2GzuGZNvL1aKnK8CQMV/jFOrxNQUMA==",
+      "dev": true,
+      "dependencies": {
+        "@vue/reactivity": "3.3.13",
+        "@vue/shared": "3.3.13"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.13.tgz",
+      "integrity": "sha512-JJkpE8R/hJKXqVTgUoODwS5wqKtOsmJPEqmp90PDVGygtJ4C0PtOkcEYXwhiVEmef6xeXcIlrT3Yo5aQ4qkHhQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/runtime-core": "3.3.13",
+        "@vue/shared": "3.3.13",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.13.tgz",
+      "integrity": "sha512-vSnN+nuf6iSqTL3Qgx/9A+BT+0Zf/VJOgF5uMZrKjYPs38GMYyAU1coDyBNHauehXDaP+zl73VhwWv0vBRBHcg==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.3.13",
+        "@vue/shared": "3.3.13"
+      },
+      "peerDependencies": {
+        "vue": "3.3.13"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.13.tgz",
+      "integrity": "sha512-/zYUwiHD8j7gKx2argXEMCUXVST6q/21DFU0sTfNX0URJroCe3b1UF6vLJ3lQDfLNIiiRl2ONp7Nh5UVWS6QnA==",
+      "dev": true
+    },
+    "node_modules/@vueuse/core": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.7.0.tgz",
+      "integrity": "sha512-4EUDESCHtwu44ZWK3Gc/hZUVhVo/ysvdtwocB5vcauSV4B7NiGY5972WnsojB3vRNdxvAt7kzJWE2h9h7C9d5w==",
+      "dev": true,
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.7.0",
+        "@vueuse/shared": "10.7.0",
+        "vue-demi": ">=0.14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.7.0.tgz",
+      "integrity": "sha512-rxiMYgS+91n93qXpHZF9NbHhppWY6IJyVTDxt4acyChL0zZVx7P8FAAfpF1qVK8e4wfjerhpEiMJ0IZ1GWUZ2A==",
+      "dev": true,
+      "dependencies": {
+        "@vueuse/core": "10.7.0",
+        "@vueuse/shared": "10.7.0",
+        "vue-demi": ">=0.14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "*",
+        "axios": "*",
+        "change-case": "*",
+        "drauu": "*",
+        "focus-trap": "*",
+        "fuse.js": "*",
+        "idb-keyval": "*",
+        "jwt-decode": "*",
+        "nprogress": "*",
+        "qrcode": "*",
+        "sortablejs": "*",
+        "universal-cookie": "*"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/integrations/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.0.tgz",
+      "integrity": "sha512-GlaH7tKP2iBCZ3bHNZ6b0cl9g0CJK8lttkBNUX156gWvNYhTKEtbweWLm9rxCPIiwzYcr/5xML6T8ZUEt+DkvA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.7.0.tgz",
+      "integrity": "sha512-kc00uV6CiaTdc3i1CDC4a3lBxzaBE9AgYNtFN87B5OOscqeWElj/uza8qVDmk7/U8JbqoONLbtqiLJ5LGRuqlw==",
+      "dev": true,
+      "dependencies": {
+        "vue-demi": ">=0.14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.0.tgz",
+      "integrity": "sha512-gfceltjkwh7PxXwtkS8KVvdfK+TSNQAWUeNSxf4dA29qW5tf2EGwa8jkJujlT9jLm17cixMVoGNc+GJFO1Mxhg==",
+      "dev": true,
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.22.0",
+        "@algolia/cache-common": "4.22.0",
+        "@algolia/cache-in-memory": "4.22.0",
+        "@algolia/client-account": "4.22.0",
+        "@algolia/client-analytics": "4.22.0",
+        "@algolia/client-common": "4.22.0",
+        "@algolia/client-personalization": "4.22.0",
+        "@algolia/client-search": "4.22.0",
+        "@algolia/logger-common": "4.22.0",
+        "@algolia/logger-console": "4.22.0",
+        "@algolia/requester-browser-xhr": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/requester-node-http": "4.22.0",
+        "@algolia/transporter": "4.22.0"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.10.tgz",
+      "integrity": "sha512-S1Y27QGt/snkNYrRcswgRFqZjaTG5a5xM3EQo97uNBnH505pdzSNe/HLBq1v0RO7iK/ngdbhJB6mDAp0OK+iUA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.10",
+        "@esbuild/android-arm": "0.19.10",
+        "@esbuild/android-arm64": "0.19.10",
+        "@esbuild/android-x64": "0.19.10",
+        "@esbuild/darwin-arm64": "0.19.10",
+        "@esbuild/darwin-x64": "0.19.10",
+        "@esbuild/freebsd-arm64": "0.19.10",
+        "@esbuild/freebsd-x64": "0.19.10",
+        "@esbuild/linux-arm": "0.19.10",
+        "@esbuild/linux-arm64": "0.19.10",
+        "@esbuild/linux-ia32": "0.19.10",
+        "@esbuild/linux-loong64": "0.19.10",
+        "@esbuild/linux-mips64el": "0.19.10",
+        "@esbuild/linux-ppc64": "0.19.10",
+        "@esbuild/linux-riscv64": "0.19.10",
+        "@esbuild/linux-s390x": "0.19.10",
+        "@esbuild/linux-x64": "0.19.10",
+        "@esbuild/netbsd-x64": "0.19.10",
+        "@esbuild/openbsd-x64": "0.19.10",
+        "@esbuild/sunos-x64": "0.19.10",
+        "@esbuild/win32-arm64": "0.19.10",
+        "@esbuild/win32-ia32": "0.19.10",
+        "@esbuild/win32-x64": "0.19.10"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/focus-trap": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
+      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
+      "dev": true,
+      "dependencies": {
+        "tabbable": "^6.2.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz",
+      "integrity": "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^8.0.0",
+        "property-information": "^6.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.1.tgz",
+      "integrity": "sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.0.tgz",
+      "integrity": "sha512-IVGhNgg7vANuUA2XKrT6sOIIPgaYZnmLx3l/CCOAK0PtgfoHrZwX7jCSYyFxHTrGmC6S9q8aQQekjp4JPZF+cw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-raw": "^9.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
+      "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
+      "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.0.2.tgz",
+      "integrity": "sha512-U5I+500EOOw9e3ZrclN3Is3fRpw8c19SMyNZlZ2IS+7vLsNzb2Om11VpIVOR+/0137GhZsFEF6YiKD5+0Hr2Og==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
+      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/minisearch": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.3.0.tgz",
+      "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ==",
+      "dev": true
+    },
+    "node_modules/mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.19.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
+      "integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.0.tgz",
+      "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.1.tgz",
+      "integrity": "sha512-pgPO9DWzLoW/vIhlSoDByCzcpX92bKEorbgXuZrqxByte3JFk2xSW2JEeAcyLc9Ru9pqcNNW+Ob7ntsk2oT/Xw==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.9.1",
+        "@rollup/rollup-android-arm64": "4.9.1",
+        "@rollup/rollup-darwin-arm64": "4.9.1",
+        "@rollup/rollup-darwin-x64": "4.9.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.1",
+        "@rollup/rollup-linux-arm64-musl": "4.9.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.1",
+        "@rollup/rollup-linux-x64-gnu": "4.9.1",
+        "@rollup/rollup-linux-x64-musl": "4.9.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.1",
+        "@rollup/rollup-win32-x64-msvc": "4.9.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
+      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/shikiji": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.2.tgz",
+      "integrity": "sha512-bxXd5iOVvuPj0NVFWQG3YMNLAGkWHyjTGixM7wLzqJNz3WMaeiOZbOP12gjQWKMJg+Ca4jmgATrUWu/rFb3B8A==",
+      "dev": true,
+      "dependencies": {
+        "hast-util-to-html": "^9.0.0"
+      }
+    },
+    "node_modules/shikiji-transformers": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.2.tgz",
+      "integrity": "sha512-WEBeNm+oUL/4OTENjnZ5G29ErNM2cPGJHRRhqjwoTFkHnsJsACtTluTaYjPEppCl46Vo3M4TV9GwrMxz2WeCSg==",
+      "dev": true,
+      "dependencies": {
+        "shikiji": "0.9.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
+      "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
+      "dev": true,
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "dev": true
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+      "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.2.tgz",
+      "integrity": "sha512-NXPYyxyBSH7zB5U6+3uDdd6Nybz6o6/od9rk8bp9H8GR3L+cm/fC0uUTbqBmUTnMCUDslAGBOIKNfvvb+gGlDg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.10.tgz",
+      "integrity": "sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.19.3",
+        "postcss": "^8.4.32",
+        "rollup": "^4.2.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.0.0-rc.32",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.32.tgz",
+      "integrity": "sha512-yf00Skn5BGP+YOQvTbSrB5s9qEb/cV+i+wM5rw+mlaxcIYtK+ORvyBEYZLvKogs7OO70TppJtixb4ofeo5K7HA==",
+      "dev": true,
+      "dependencies": {
+        "@docsearch/css": "^3.5.2",
+        "@docsearch/js": "^3.5.2",
+        "@types/markdown-it": "^13.0.7",
+        "@vitejs/plugin-vue": "^4.5.2",
+        "@vue/devtools-api": "^6.5.1",
+        "@vueuse/core": "^10.7.0",
+        "@vueuse/integrations": "^10.7.0",
+        "focus-trap": "^7.5.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^6.3.0",
+        "mrmime": "^1.0.1",
+        "shikiji": "0.9.2",
+        "shikiji-transformers": "0.9.2",
+        "vite": "^5.0.10",
+        "vue": "^3.3.11"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4.3.2",
+        "postcss": "^8.4.32"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.13.tgz",
+      "integrity": "sha512-LDnUpQvDgsfc0u/YgtAgTMXJlJQqjkxW1PVcOnJA5cshPleULDjHi7U45pl2VJYazSSvLH8UKcid/kzH8I0a0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.3.13",
+        "@vue/compiler-sfc": "3.3.13",
+        "@vue/runtime-dom": "3.3.13",
+        "@vue/server-renderer": "3.3.13",
+        "@vue/shared": "3.3.13"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "devDependencies": {
+    "vitepress": "^1.0.0-rc.32"
+  },
+  "scripts": {
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
+  }
+}


### PR DESCRIPTION
This PR adds a new docs site powered by [VitePress](https://vitepress.dev). The docs become part of the source repo, rather than in a separate repo, which is easier for users to find and keeps them versioned together with the library.

I've mostly copy/pasted from the [existing site](https://github.com/linc/nitroporter.org), with the most substantial change to the User Guide which is now titled Quick Start. The instructions on this page are currently hypothetical - this is my current thinking for the UX of Porter - hence this PR is a draft and should not yet be merged. Specifically:

- Now that Porter is exclusively a CLI tool, `composer global require` is the recommended installation method
- Will need to add an `porter init` command to generate a new config file
- Changes to the config file - make `connections` a keyed array and use database config keys directly from Illuminate. (Not sure if the other config options are still needed?)
- I envision the `run` command will allow you to select platforms from a list (rather than having to know the name to type)
- I envision the `run` command will automatically use database connections named `source` and `target` if they are present

Let me know what you think about this, I'm keen to contribute these changes if they sound okay.

A GitHub action is included which will deploy the docs to GitHub Pages for the repo. See [here](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow) for how to configure this to work.

Preview the docs locally by running:

```
npm i
npm run docs:dev
```