### PR TITLE
fix: prevent deletion of mapped row data

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -106,7 +106,9 @@ abstract class Storage
             foreach ($row as $columnName => $value) {
                 if ($columnName === $src) {
                     $row[$dest] = $value; // Add column with new name.
-                    unset($row[$columnName]); // Remove old column.
+                    if ($dest !== $columnName) {
+                        unset($row[$columnName]); // Remove old column.
+                    }
                 }
             }
         }


### PR DESCRIPTION
In the `mapData()` storage step, row columns would be removed if the mapped destination column name and the row's column names were the same. The fix adds a check to skip the removal if the names match.

For instance, the Vanilla 1 user map data looks like this:
```php
Array (
    [UserID] => UserID
    [Name] => Name
    [Password] => Password
    [Email] => Email
    [Icon] => Photo
    [CountComments] => CountComments
    [Discovery] => DiscoveryText
)
```
The bug would cause fields like `UserID` and `Name` to be deleted from the row.

Refer to the discussion for more information and implications: https://github.com/linc/nitro-porter/discussions/38