### PR TITLE
Fix autoload to work in more scenarios

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,7 +1,20 @@
 <?php
 
 // Autoload.
-require_once __DIR__ . '/vendor/autoload.php';
+if (isset($GLOBALS['_composer_autoload_path'])) {
+    // If running via Composer, use provided location.
+    require_once $GLOBALS['_composer_autoload_path'];
+} else {
+    // If running locally, guess the location.
+    foreach (['../..', '../vendor', 'vendor'] as $path) {
+        $autoloader = __DIR__ . '/' . $path . '/autoload.php';
+        if (file_exists($autoloader)) {
+            require_once $autoloader;
+            unset($autoloader);
+            break;
+        }
+    }
+}
 
 // Environment.
 const ROOT_DIR = __DIR__;


### PR DESCRIPTION
Resolves autoloader confusion between global Composer runs & local repo runs by preferring the defined Composer autoloader location and then guessing a bit if we're directly calling `bin/porter` from elsewhere. Can always add more use cases (possible relative paths) later if it proves an issue.

Reported in https://github.com/linc/nitro-porter/discussions/53

Cheers to @imliam for the [solution](https://liamhammett.com/detecting-autoloaders-in-composer-bin-commands), very slightly refactored here. I probably should have gone further made it an `array_map` but I'm tapping out as this is good enough for Boxing Day. 🙃