### PR TITLE
Add config validation step

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -69,8 +69,36 @@ class Config
         foreach ($this->config['connections'] as $connection) {
             if ($alias === $connection['alias']) {
                 $result = $connection;
+                break;
             }
         }
+
+        $this->validateConnectionInfo($alias, $result);
+
         return $result;
+    }
+
+    /**
+     * Validate config has required info.
+     *
+     * @param string $alias
+     * @param array $info
+     */
+    protected function validateConnectionInfo(string $alias, array $info): void
+    {
+        // Type is required.
+        if (empty($info['type'])) {
+            trigger_error('Config error: No connection `type` for alias "' . $alias . '"', E_USER_ERROR);
+        }
+
+        // Database required fields.
+        if ($info['type'] === 'database') {
+            foreach (['adapter', 'host','name','user'] as $required_field) {
+                if (!array_key_exists($required_field, $info)) {
+                    trigger_error('Config error: Database `' . $required_field .
+                        '` missing for alias "' . $alias . '"', E_USER_ERROR);
+                }
+            }
+        }
     }
 }

--- a/src/ConnectionManager.php
+++ b/src/ConnectionManager.php
@@ -38,10 +38,6 @@ class ConnectionManager
             $info = Config::getInstance()->getTestConnection();
         }
 
-        if (!isset($info['type'])) {
-            trigger_error('Config error: Connection `type` not found for  "' . $alias . '"', E_USER_ERROR);
-        }
-
         $this->setInfo($info);
         $this->setType($info['type']);
 


### PR DESCRIPTION
Validates config has a `type` for the connection being used.
For databases, validate it has a few more required fields.

Rethinks https://github.com/linc/nitro-porter/pull/57 into a better structure & extends it.
Further discussion of https://github.com/linc/nitro-porter/discussions/56