### PR TITLE
Add Vanilla avatar filename processing

### DIFF
--- a/src/Source/Vanilla.php
+++ b/src/Source/Vanilla.php
@@ -65,7 +65,6 @@ class Vanilla extends Source
             'Role',
             'Tag',
             'TagDiscussion',
-            'User',
             'UserComment',
             'UserConversation',
             'UserDiscussion',
@@ -82,6 +81,17 @@ class Vanilla extends Source
         $this->ranks($ex);
         $this->reactions($ex);
         $this->polls($ex);
+    }
+
+    /**
+     * @param ExportModel $ex
+     */
+    public function users(ExportModel $ex)
+    {
+        $map = [
+            'Photo' => ['Column' => 'Photo', 'Type' => 'string', 'Filter' => 'vanillaPhoto'],
+        ];
+        $ex->export('User', "select * from :_User u", $map);
     }
 
     /**

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PorterTest;
+
+use PHPUnit\Framework\TestCase;
+
+final class FilterTest extends TestCase
+{
+    /**
+     * @covers \vanillaPhoto
+     */
+    public function testParseRender()
+    {
+        $photoTests = [
+            // Add 'p'
+            'userpics/396/YGIC427MJADQ.jpg' => 'userpics/396/pYGIC427MJADQ.jpg',
+            'uploads/userpics/820/4J95NK90AFDT.jpeg' => 'uploads/userpics/820/p4J95NK90AFDT.jpeg',
+            // No change; URL
+            'https://example.com/forum/uploads/userpics/396/YGIC427MJADQ.jpg'
+                => 'https://example.com/forum/uploads/userpics/396/YGIC427MJADQ.jpg',
+            // No change; not Vanilla origin - filename pattern
+            'userpics/avatar11_4.gif' => 'userpics/avatar11_4.gif',
+            // No change; not Vanilla origin - extension
+            'userpics/396/YGIC427MJADQ.ext' => 'userpics/396/YGIC427MJADQ.ext',
+        ];
+        foreach ($photoTests as $input => $expectedOutput) {
+            $testOutput = \vanillaPhoto($input);
+            $this->assertEquals($testOutput, $expectedOutput);
+        }
+    }
+}


### PR DESCRIPTION
Vanilla prepends avatar images with `n` (thumbnail) or `p` (profile/fullsize) in the filesystem, but stores the `User.Photo` in the database without either because it does the substitution on pageload. If we're exporting from Vanilla, we probably want `User.Photo` to match the valid fullsize avatar file path. 

However, `User.Photo` only gets processed like this IF VANILLA UPLOADED THE FILE. Images from previous imports, CDN uploads, or full URLs are not processed, so we need to skip those.

To process the `User.Photo` field, we need to pull the `User` table out of the mass-batching in the Vanilla source and actually map that column.

This is one of those squarely cases where my Vanilla knowledge comes in exceptionally handy. 🙃 Several test scenarios are included to further explain how many possible outcomes there are.

The one drawback of this PR is that it introduces a case where a Vanilla -> Vanilla migration isn't entirely lossless, but I think that's a rare enough case, and this logic sufficiently challenging to do successfully after the fact, that it's entirely worth it.