### PR TITLE
Fix column name error introduced in previous fix

### DIFF
--- a/src/Target/Flarum.php
+++ b/src/Target/Flarum.php
@@ -334,7 +334,7 @@ class Flarum extends Target
         $query = $ex->dbImport()->table('PORT_Category')
             ->select(
                 '*',
-                $ex->dbImport()->raw('COALESCE(Name, CONCAT("category", id)) as name'), // Cannot be null.
+                $ex->dbImport()->raw('COALESCE(Name, CONCAT("category", CategoryID)) as name'), // Cannot be null.
                 $ex->dbImport()->raw("if(ParentCategoryID = -1, null, ParentCategoryID) as ParentCategoryID"),
                 $ex->dbImport()->raw("0 as is_hidden"),
                 $ex->dbImport()->raw("0 as is_restricted")


### PR DESCRIPTION
I did a bad fix here: https://github.com/linc/nitro-porter/commit/db5d542f99a2b63d921b372ea7e8aad45574fa42

I referenced the _target_ column `id` instead of the `port_` column `CategoryID`.

Reported in https://github.com/linc/nitro-porter/discussions/61

