### PR TITLE
Missing call to Vanilla Users method

### DIFF
--- a/src/Source/Vanilla.php
+++ b/src/Source/Vanilla.php
@@ -77,6 +77,7 @@ class Vanilla extends Source
             }
         }
 
+        $this->users($ex);
         $this->badges($ex);
         $this->ranks($ex);
         $this->reactions($ex);


### PR DESCRIPTION
Fix missing method call, bug introduced in https://github.com/linc/nitro-porter/pull/60
Reported in https://github.com/linc/nitro-porter/discussions/61#discussioncomment-11680423 