### PR TITLE
Add new Vanilla fields for parity with upstream

### DIFF
--- a/data/structure.php
+++ b/data/structure.php
@@ -231,6 +231,7 @@ return array(
         'Type' => 'varchar(10)',
         'ForeignID' => 'varchar(200)',
         'CategoryID' => 'int',
+        "statusID" => "int",
         'InsertUserID' => 'int',
         'UpdateUserID' => 'int',
         'FirstCommentID' => 'int',
@@ -705,7 +706,10 @@ return array(
         'UserID' => 'int',
         'CategoryID' => 'int',
         'DateMarkedRead' => 'datetime',
-        'Unfollow' => 'tinyint'
+        "Followed" => "tinyint",
+        'Unfollow' => 'tinyint',
+        "DateFollowed" => "datetime",
+        "DateUnfollowed" => "datetime",
     ),
     'UserComment' => array(
         'UserID' => 'int',

--- a/data/structure.php
+++ b/data/structure.php
@@ -184,6 +184,9 @@ return array(
     'Comment' => array(
         'CommentID' => 'int',
         'DiscussionID' => 'int',
+        "parentRecordType" => "varchar(10)",
+        "parentRecordID" => "int",
+        "parentCommentID" => "int",
         'InsertUserID' => 'int',
         'UpdateUserID' => 'int',
         'DeleteUserID' => 'int',


### PR DESCRIPTION
From: 
1. https://github.com/vanilla/porter/pull/221 (https://github.com/vanilla/porter/pull/221/commits/e68594e649eb10fb56b62221b46ac2b351135e89)
2. https://github.com/vanilla/porter/commit/3795bb206f5c6b114d1ccbceeec2a0c3dcdd309f