### PR TITLE
Avatars imported to Vanilla from vBulletin need the 'p' prefix

### DIFF
--- a/src/Functions/filter.php
+++ b/src/Functions/filter.php
@@ -609,6 +609,11 @@ function bb_Decodeit($matches)
  */
 function vanillaPhoto($path)
 {
+    // Skip processing for blank entries.
+    if ($path === '') {
+        return '';
+    }
+
     // Vanilla can have URLs in the Photo field.
     if (strrpos($path, 'http') === 0) {
         return $path;

--- a/src/Functions/filter.php
+++ b/src/Functions/filter.php
@@ -621,8 +621,13 @@ function vanillaPhoto($path)
 
     $filename = basename($path);
     // Only convert Vanilla-processed avatars (skip previous imports)
+    // OR vBulletin-imported avatars (which got special post-processing in Vanilla, along with SM2 imports)
     // @see Vanilla\FileUtils::generateUniqueUploadPath()
-    if (preg_match('/[A-Z0-9]{12}\.(jpg|jpeg|gif|png)/', $filename) !== 1) {
+    // @see \vBulletinImportModel::processAvatars()
+    if (
+        preg_match('/[A-Z0-9]{12}\.(jpg|jpeg|gif|png)/', $filename) !== 1
+        && preg_match('/avatar[0-9_]+\.(jpg|jpeg|gif)/', $filename) !== 1
+    ) {
         return $path;
     }
     // Don't recursively add 'p' to filenames.

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -12,14 +12,16 @@ final class FilterTest extends TestCase
     public function testParseRender()
     {
         $photoTests = [
-            // Add 'p'
+            // Add 'p' - Vanilla origin
             'userpics/396/YGIC427MJADQ.jpg' => 'userpics/396/pYGIC427MJADQ.jpg',
             'uploads/userpics/820/4J95NK90AFDT.jpeg' => 'uploads/userpics/820/p4J95NK90AFDT.jpeg',
+            // Add 'p' - vBulletin -> Vanilla origin
+            'userpics/avatar11_4.gif' => 'userpics/pavatar11_4.gif',
             // No change; URL
             'https://example.com/forum/uploads/userpics/396/YGIC427MJADQ.jpg'
                 => 'https://example.com/forum/uploads/userpics/396/YGIC427MJADQ.jpg',
             // No change; not Vanilla origin - filename pattern
-            'userpics/avatar11_4.gif' => 'userpics/avatar11_4.gif',
+            'userpics/aaa919.gif' => 'userpics/aaa919.gif',
             // No change; not Vanilla origin - extension
             'userpics/396/YGIC427MJADQ.ext' => 'userpics/396/YGIC427MJADQ.ext',
         ];


### PR DESCRIPTION
In discussion https://github.com/linc/nitro-porter/discussions/65 we realized the Vanilla avatars that previously imported from vBulletin will have the 'p' prefix due to a unique post-processing step for vBulletin imports in Vanilla. Here, we use the fact that vBulletin avatars all started with `avatar` followed with a user ID & version separated by an underscore to detect those cases and also transform them.

SMF2 also shares this step, but unfortunately I don't have sample data to write that edge case.