### PR TITLE
Upgrade dependencies & require PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,24 +31,24 @@
         "bin/porter"
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.2",
         "ext-gd": "*",
         "ext-json": "*",
         "ext-pdo": "*",
         "ext-zlib": "*",
-        "illuminate/database": "^8.0",
-        "monolog/monolog": "^2",
+        "illuminate/database": "^11",
+        "monolog/monolog": "^3",
         "adhocore/cli": "^1",
         "s9e/text-formatter": "2.15.*",
-        "nadar/quill-delta-parser": "^2"
+        "nadar/quill-delta-parser": "^3"
     },
     "require-dev": {
-        "phing/phing": "^2.0",
-        "robmorgan/phinx": "^0.12",
-        "fakerphp/faker": "^1.16",
+        "phing/phing": "^2",
+        "robmorgan/phinx": "^0",
+        "fakerphp/faker": "^1",
         "squizlabs/php_codesniffer": "^3",
         "phpunit/phpunit": "^9",
-        "phpstan/phpstan": "^1",
+        "phpstan/phpstan": "^2",
         "marcocesarato/php-conventional-changelog": "^1"
     },
     "autoload": {

--- a/src/ExportModel.php
+++ b/src/ExportModel.php
@@ -131,13 +131,9 @@ class ExportModel
     {
         if (!empty($tables)) {
             $tables = explode(',', $tables);
-
-            if (is_array($tables)) {
-                $tables = array_map('trim', $tables);
-                $tables = array_map('strtolower', $tables);
-
-                $this->limitedTables = $tables;
-            }
+            $tables = array_map('trim', $tables);
+            $tables = array_map('strtolower', $tables);
+            $this->limitedTables = $tables;
         }
     }
 

--- a/src/Source/Drupal7.php
+++ b/src/Source/Drupal7.php
@@ -77,8 +77,7 @@ class Drupal7 extends Source
         preg_replace_callback(
             self::PATTERN,
             function ($matches) use ($postId) {
-                $file = base64_decode($matches[1]);
-                if ($file !== false) {
+                if ($file = base64_decode($matches[1])) {
                     $filename = "{$postId}_{$this->imageCount}.png";
                     $this->imageCount++;
                     file_put_contents($this->param('attach-source', null) . '/' . $filename, $file);

--- a/src/Target/Flarum.php
+++ b/src/Target/Flarum.php
@@ -124,7 +124,7 @@ class Flarum extends Target
 
     /**
      * @param ExportModel $ex
-     * @return string[]
+     * @return array
      */
     protected function getStructureDiscussions(ExportModel $ex)
     {


### PR DESCRIPTION
* Move to Illuminate Database 11
* Require PHP 8.2 (while 8.1 is [supported](https://www.php.net/supported-versions.php) for another year, Illuminate 11 requires it)
* Version upgrades for Monolog, Quill Parser, & PHPStan
* Minor version syntax fixes in composer.json for Phinx & Faker.
* 3 minor fixes to quiet PHPStan (novel errors detected after the upgrade).

Phing 3 is available, but there are [issues with that upgrade](https://github.com/users/linc/projects/2/views/1?pane=issue&itemId=92196793), so it's deferred for now.