### PR TITLE
Refactor the main workflow & connection handling

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -59,10 +59,10 @@ class RunCommand extends Command
             $this->target ?? '',
             $this->input ?? '',
             $this->output ?? '',
-            $this->sp ?? '',
-            $this->tp ?? '',
-            $this->cdn ?? '',
-            $this->data ?? ''
+            $this->sp,
+            $this->tp,
+            $this->cdn,
+            $this->data
         );
 
         \Porter\Controller::run($request);

--- a/src/ConnectionManager.php
+++ b/src/ConnectionManager.php
@@ -20,10 +20,7 @@ class ConnectionManager
     protected array $info = [];
 
     /** @var Connection Connection used for reads. */
-    protected Connection $readConnection;
-
-    /** @var Connection Connection used for writes. */
-    protected Connection $writeConnection;
+    protected Connection $connection;
 
     public Capsule $dbm;
 
@@ -31,7 +28,6 @@ class ConnectionManager
      * If no connect alias is give, initiate a test connection.
      *
      * @param string $alias
-     * @return array Connection info.
      */
     public function __construct(string $alias = '')
     {
@@ -51,9 +47,7 @@ class ConnectionManager
             $capsule = new Capsule();
             $capsule->addConnection($this->translateConfig($info), $info['alias']);
             $this->dbm = $capsule;
-            // Separate read/write connections for unbuffered queries.
-            $this->readConnection = $this->newConnection();
-            $this->writeConnection = $this->newConnection();
+            $this->connection = $this->newConnection();
         }
     }
 
@@ -95,19 +89,9 @@ class ConnectionManager
      *
      * @return Connection
      */
-    public function readConnection(): Connection
+    public function connection(): Connection
     {
-        return $this->readConnection;
-    }
-
-    /**
-     * Get the current DBM connection.
-     *
-     * @return Connection
-     */
-    public function writeConnection(): Connection
-    {
-        return $this->writeConnection;
+        return $this->connection;
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -65,6 +65,8 @@ class Request
             $this->dataTypes = $dataTypes;
         } elseif (!empty($dataTypes)) {
             throw new \Exception('Invalid data types in request.');
+        } else {
+            $this->dataTypes = '';
         }
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -24,10 +24,10 @@ class Request
     private string $targetPackage;
     private string $inputConnection;
     private string $outputConnection;
-    private string $inputTablePrefix;
-    private string $outputTablePrefix;
-    private string $cdnPrefix;
-    private string $dataTypes;
+    private ?string $inputTablePrefix;
+    private ?string $outputTablePrefix;
+    private ?string $cdnPrefix;
+    private ?string $dataTypes;
 
     /**
      * Build a valid Porter request.
@@ -36,20 +36,21 @@ class Request
      * @param string $targetPackage Target package alias (or 'file', 'sql')
      * @param string $inputConnection Connection alias in config.php
      * @param string $outputConnection Connection alias in config.php
-     * @param string $inputTablePrefix If the input is a database, override source package with this table prefix.
-     * @param string $outputTablePrefix If the output is a database, override target package with this table prefix.
-     * @param string $cdnPrefix Text to prepend to attachment URIs.
-     * @param string $dataTypes CSV of types or 'all' (ex: `users,categories,discussions`)
+     * @param ?string $inputTablePrefix If the input is a database, override source package with this table prefix.
+     * @param ?string $outputTablePrefix If the output is a database, override target package with this table prefix.
+     * @param ?string $cdnPrefix Text to prepend to attachment URIs.
+     * @param ?string $dataTypes CSV of types or 'all' (ex: `users,categories,discussions`)
+     * @throws \Exception
      */
     public function __construct(
         string $sourcePackage,
         string $targetPackage,
         string $inputConnection,
         string $outputConnection,
-        string $inputTablePrefix,
-        string $outputTablePrefix,
-        string $cdnPrefix,
-        string $dataTypes,
+        ?string $inputTablePrefix = null,
+        ?string $outputTablePrefix = null,
+        ?string $cdnPrefix = null,
+        ?string $dataTypes = null,
     ) {
         $this->sourcePackage = $sourcePackage;
         $this->targetPackage = $targetPackage;
@@ -66,7 +67,7 @@ class Request
         } elseif (!empty($dataTypes)) {
             throw new \Exception('Invalid data types in request.');
         } else {
-            $this->dataTypes = '';
+            $this->dataTypes = null;
         }
     }
 
@@ -90,22 +91,22 @@ class Request
         return $this->outputConnection;
     }
 
-    public function getInputTablePrefix(): string
+    public function getInputTablePrefix(): ?string
     {
         return $this->inputTablePrefix;
     }
 
-    public function getOutputTablePrefix(): string
+    public function getOutputTablePrefix(): ?string
     {
         return $this->outputTablePrefix;
     }
 
-    public function getCdnPrefix(): string
+    public function getCdnPrefix(): ?string
     {
         return $this->cdnPrefix;
     }
 
-    public function getDataTypes(): string
+    public function getDataTypes(): ?string
     {
         return $this->dataTypes;
     }

--- a/src/Source/VBulletin5.php
+++ b/src/Source/VBulletin5.php
@@ -350,7 +350,7 @@ class VBulletin5 extends VBulletin
 
         // We have to generate a sort order so let's do the exportation manually line by line....
         list($revMappings, $legacyFilter) = $ex->normalizeDataMap($pollOption_Map);
-        $exportStructure = $ex->mapStructure['PollOption'];
+        //$exportStructure = $ex->porterStructure['PollOption'];
         //$exportStructure = getExportStructure($pollOption_Map, $ex->mapStructure['PollOption'], $pollOption_Map);
         //$revMappings = flipMappings($pollOption_Map);
 

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -45,6 +45,8 @@ abstract class Storage
 
     abstract public function endStream();
 
+    abstract public function getAlias(): string;
+
     /**
      * Prepare a row of data for storage.
      *

--- a/src/Storage/Database.php
+++ b/src/Storage/Database.php
@@ -60,6 +60,19 @@ class Database extends Storage
     }
 
     /**
+     * @return ConnectionManager
+     */
+    public function getConnection(): ConnectionManager
+    {
+        return $this->connection;
+    }
+
+    public function getAlias(): string
+    {
+        return $this->connection->getAlias();
+    }
+
+    /**
      * Save the given records to the database. Use prefix.
      *
      * @param string $name
@@ -187,7 +200,7 @@ class Database extends Storage
         $tableName = $this->getBatchTable();
         $action = (in_array($tableName, $this->ignoreErrorsTables)) ? 'insertOrIgnore' : 'insert';
         try {
-            $this->connection->connection()->table($tableName)->$action($batch);
+            $this->connection->writeConnection()->table($tableName)->$action($batch);
         } catch (\Illuminate\Database\QueryException $e) {
             echo "\n\nBatch insert error: " . substr($e->getMessage(), 0, 500);
             echo "\n[...]\n" . substr($e->getMessage(), -300) . "\n";

--- a/src/Storage/Database.php
+++ b/src/Storage/Database.php
@@ -96,7 +96,6 @@ class Database extends Storage
             'memory' => 0,
         ];
         $this->setBatchTable($name);
-        $this->connection->newConnection();
 
         if (is_a($data, '\Porter\Database\ResultSet')) {
             // Iterate on old ResultSet.
@@ -200,7 +199,7 @@ class Database extends Storage
         $tableName = $this->getBatchTable();
         $action = (in_array($tableName, $this->ignoreErrorsTables)) ? 'insertOrIgnore' : 'insert';
         try {
-            $this->connection->writeConnection()->table($tableName)->$action($batch);
+            $this->connection->connection()->table($tableName)->$action($batch);
         } catch (\Illuminate\Database\QueryException $e) {
             echo "\n\nBatch insert error: " . substr($e->getMessage(), 0, 500);
             echo "\n[...]\n" . substr($e->getMessage(), -300) . "\n";

--- a/src/Storage/File.php
+++ b/src/Storage/File.php
@@ -43,6 +43,14 @@ class File extends Storage
     protected bool $useCompression = true;
 
     /**
+     * @return string
+     */
+    public function getAlias(): string
+    {
+        return 'file';
+    }
+
+    /**
      * Whether or not to use compression on the output file.
      *
      * @param  bool $value The value to set or NULL to just return the value.

--- a/src/Support.php
+++ b/src/Support.php
@@ -91,7 +91,7 @@ class Support
     {
         // Hardcode Vanilla file support (all = yes).
         $this->targets['file'] = [
-            'name' => 'Vanilla',
+            'name' => 'Vanilla (file)',
             'features' => array_fill_keys(self::SUPPORTED_FEATURES, 1),
         ];
 


### PR DESCRIPTION
- Improves clarity of logging output
- Improves clarity of `Controller::run()`
- Improves DI for `ExportModel`
- Separates `Storage` between Porter (export write / import read) & Output (import write) operations more clearly
- Allows nullable extra options

There was still a lot of mental model issues kicking around in how things were named which made it difficult to understand the main `run()` sequence and how database connections were being used. This is a big step towards clarifying it all and better encapsulating concerns so that we can add automated testing.

The main refactor is obviously in https://github.com/linc/nitro-porter/pull/92/commits/e1f5f14ad50a951d971422c7deac367f7fefd6d3 with the rest as more minor supporting changes. In retrospect, https://github.com/linc/nitro-porter/pull/92/commits/4599318e997981b275ca12571bded849226b71f9 was partially in error — the connection separation needed to happen a level higher (2 `ConnectionManager`s, not 2 connections in 1 manager). We now use 2 `Storage` objects (instead of 1), because the intermediary Porter gets its own separate from Output, which removes the read/write contention on its database connection during the import step without resetting the connection arbitrarily.