### PR TITLE
Add Agorakit as target (NLNet 6a-b)

### DIFF
--- a/data/targets.php
+++ b/data/targets.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'Agorakit',
     'Flarum',
     'Waterhole',
 ];

--- a/src/Package.php
+++ b/src/Package.php
@@ -31,6 +31,9 @@ abstract class Package
 
     /** @var array|string[] Auto-run() this list of methods unless overwritten per-package. */
     protected const array MANIFEST = [
+        // prepare
+        'setup', // HOOK
+        'filemap', // Map a file transfer.
         // users
         'users', // inc. usermeta, signatures
         'roles',
@@ -39,6 +42,7 @@ abstract class Package
         'categories',
         'groups',
         // content
+        'precontent', // HOOK
         'discussions',
         'comments',
         'conversations',
@@ -53,6 +57,8 @@ abstract class Package
         'avatars',
         'attachments',
         'emojis',
+        // finalize
+        'cleanup', // HOOK
     ];
 
     /**

--- a/src/Target.php
+++ b/src/Target.php
@@ -204,4 +204,42 @@ abstract class Target extends Package
         // Report.
         Log::storage('import', $tableName, microtime(true) - $start, $info['rows'], $info['memory']);
     }
+
+    /**
+     * Setup the destination values for FileTransfer.
+     * Requires package implements mapAttachments() and/or mapAvatars().
+     */
+    protected function filemap(): void
+    {
+        // Abort if we lack support.
+        if (!$this->getFileTransferSupport()) {
+            return;
+        }
+
+        // Map attachments if self::SUPPORTED[attachmentPath] exists.
+        if (method_exists($this, 'mapAttachments') && $fileTarget = $this->getPath('attachment', 'full')) {
+            // Start timer.
+            $start = microtime(true);
+            Log::comment("Mapping attachments...");
+
+            // Query & update.
+            $rows = $this->mapAttachments($fileTarget);
+
+            // Report.
+            Log::storage('map', 'Media.TargetFullPath', microtime(true) - $start, $rows, memory_get_usage());
+        }
+
+        // Map avatars if self::SUPPORTED[avatarPath] exists.
+        if (method_exists($this, 'mapAvatars') && $fileTarget = $this->getPath('avatar', 'full')) {
+            // Start timer.
+            $start = microtime(true);
+            Log::comment("Mapping avatars...");
+
+            // Query & update.
+            $rows = $this->mapAvatars($fileTarget);
+
+            // Report.
+            Log::storage('map', 'User.TargetAvatarFullPath', microtime(true) - $start, $rows, memory_get_usage());
+        }
+    }
 }

--- a/src/Target/Agorakit.php
+++ b/src/Target/Agorakit.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * @author Lincoln Russell, lincolnwebs.com
+ */
+
+namespace Porter\Target;
+
+use Porter\Migration;
+use Porter\Target;
+
+/**
+ *
+ */
+class Agorakit extends Target
+{
+    public const SUPPORTED = [
+        'name' => 'Agorakit',
+        'defaultTablePrefix' => '',
+        //'avatarPath' => '',
+        //'attachmentPath' => '',
+        'features' => [
+            // round 0 - base
+            'Users' => 1,
+            'Passwords' => 1,
+            'Discussions' => 1,
+            'Comments' => 1,
+            // round 1 - mash
+            'Categories' => 0, // @todo TAGS
+            'Tags' => 0, // @todo ALSO TAGS
+            'Roles' => 0, // @todo GROUPS
+            'Groups' => 0, // @todo ALSO GROUPS
+            // round 2 - kludge
+            'Avatars' => 0, // @todo FILES
+            'Attachments' => 0, // @todo ALSO FILES
+            'Reactions' => 0, // @todo REACTIONS ???
+            // round 3 - create
+            'Bookmarks' => 0, // @todo no support
+            'Polls' => 0, // @todo no support
+            'Badges' => 0, // @todo no support
+            // round 4 - rethink
+            'PrivateMessages' => 0, // @todo no support
+        ]
+    ];
+
+    protected const FLAGS = [
+        'hasDiscussionBody' => true,
+    ];
+
+    /** @var int Offset for inserting OP content into the posts table. */
+    protected int $discussionPostOffset = 0;
+
+    /**
+     * Main import process.
+     */
+    public function run(Migration $port): void
+    {
+        $this->users($port);
+        $this->roles($port);
+        $this->categories($port);
+
+        $this->discussions($port);
+        $this->comments($port);
+    }
+
+    /**
+     * Check for issues that will break the import.
+     *
+     * @param Migration $port
+     */
+    public function validate(Migration $port): void
+    {
+        //
+    }
+
+    /**
+     * @param Migration $port
+     */
+    protected function users(Migration $port): void
+    {
+        $structure = [
+            'id' => 'int',
+            'name' => 'varchar(100)',
+            'username' => 'varchar(100)',
+            'email' => 'varchar(100)',
+            'verified' => 'tinyint',
+            'password' => 'varchar(100)',
+            'created_at' => 'datetime',
+            'admin' => 'tinyint',
+        ];
+        $map = [
+            'UserID' => 'id',
+            'Name' => 'username',
+            'FullName' => 'name',
+            'Email' => 'email',
+            'Password' => 'password',
+            'Confirmed' => 'verified',//
+            //'Photo' => 'avatar_url',
+            'DateInserted' => 'created_at',
+            'Admin' => 'admin',
+        ];
+        $filters = [];
+        $query = $port->targetQB()
+            ->from('User')
+            ->select();
+
+        $port->import('users', $query, $structure, $map, $filters);
+    }
+
+    /**
+     *
+     * @param Migration $port
+     */
+    protected function roles(Migration $port): void
+    {
+        $structure = [
+            'id' => 'int',
+            'name_singular' => 'varchar(100)',
+        ];
+        $map = [];
+        $query = $port->targetQB()
+            ->from('Role')
+            ->select();
+
+        $port->import('groups', $query, $structure, $map);
+
+        // User Role.
+        $structure = [
+            'user_id' => 'int',
+            'group_id' => 'int',
+        ];
+        $map = [
+            'UserID' => 'user_id',
+            'RoleID' => 'group_id',
+        ];
+        $query = $port->targetQB()
+            ->from('UserRole')
+            ->select();
+
+        $port->import('group_user', $query, $structure, $map);
+    }
+
+    /**
+     * @param Migration $port
+     */
+    protected function categories(Migration $port): void
+    {
+        $structure = [
+            'id' => 'int',
+            'name' => 'varchar(100)',
+            'slug' => 'varchar(100)',
+            'description' => 'text',
+            'parent_id' => 'int',
+            'position' => 'int',
+            'discussion_count' => 'int',
+            'is_hidden' => 'tinyint',
+            'is_restricted' => 'tinyint',
+        ];
+        $map = [
+            'CategoryID' => 'id',
+            'Name' => 'name',
+            'Description' => 'description',
+            'ParentCategoryID' => 'parent_id',
+            'Sort' => 'position',
+            'CountDiscussions' => 'discussion_count',
+        ];
+        $filters = [
+            'CountDiscussions' => 'emptyToZero',
+        ];
+        $query = $port->targetQB()
+            ->from('Category')
+            ->select()
+            ->where('CategoryID', '!=', -1); // Ignore Vanilla's root category.
+
+        $port->import('tags', $query, $structure, $map, $filters);
+    }
+
+    /**
+     * @param Migration $port
+     */
+    protected function discussions(Migration $port): void
+    {
+        $structure = [];
+        $map = [
+            'DiscussionID' => 'id',
+            'InsertUserID' => 'user_id',
+            'CategoryID' => 'group_id',
+            'Name' => 'name',
+            'Body' => 'body',
+            'DateInserted' => 'created_at',
+            'DateUpdated' => 'updated_at',
+            //'FirstCommentID' => 'first_post_id',
+            //'LastCommentID' => 'last_post_id',
+            //'DateLastComment' => 'last_posted_at',
+            //'LastCommentUserID' => 'last_posted_user_id',
+            'CountComments' => 'total_comments',
+            //'Announce' => 'status',
+            //'Closed' => '',
+        ];
+        $filters = [];
+        $query = $port->targetQB()
+            ->from('Discussion')
+            ->select();
+
+        $port->import('discussions', $query, $structure, $map, $filters);
+    }
+
+    /**
+     * @param Migration $port
+     */
+    protected function comments(Migration $port): void
+    {
+        $structure = [];
+        $map = [
+            'CommentID' => 'id',
+            'DiscussionID' => 'discussion_id',
+            'InsertUserID' => 'user_id',
+            'DateInserted' => 'created_at',
+            'DateUpdated' => 'updated_at',
+            'Body' => 'body'
+        ];
+        $filters = [];
+        $query = $port->targetQB()
+            ->from('Comment')
+            ->select();
+
+        // @todo !hasDiscussionBody support
+
+        $port->import('posts', $query, $structure, $map, $filters);
+    }
+}

--- a/src/Target/Agorakit.php
+++ b/src/Target/Agorakit.php
@@ -16,8 +16,8 @@ class Agorakit extends Target
     public const array SUPPORTED = [
         'name' => 'Agorakit',
         'defaultTablePrefix' => '',
-        //'avatarPath' => '',
-        //'attachmentPath' => '',
+        'avatarPath' => 'storage/app/users',
+        'attachmentPath' => 'storage/app/import',
         'features' => [
             'Users' => 1,
             'Passwords' => 1,
@@ -89,12 +89,31 @@ class Agorakit extends Target
 
     protected const SCHEMA_ROLES = [
         'id' => 'int',
-        'name_singular' => 'varchar(100)',
+        'name' => 'varchar(100)',
+        'body' => 'text',
     ];
 
     protected const SCHEMA_USER_ROLES = [
         'user_id' => 'int',
         'group_id' => 'int',
+    ];
+
+    protected const SCHEMA_ATTACHMENTS = [
+        'id' => 'int',
+        'parent_id' => 'int',
+        'group_id' => 'int',
+        'user_id' => 'int',
+        'item_type' => 'int',
+        'filesize' => 'int',
+        'status' => 'int',
+        'name' => 'varchar(100)',
+        'mime' => 'varchar(100)',
+        'path' => 'text',
+        'original_filename' => 'text',
+        'original_extension' => 'text',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+        'deleted_at' => 'datetime',
     ];
 
     /**
@@ -209,18 +228,88 @@ class Agorakit extends Target
         $this->import('posts', $query, self::SCHEMA_COMMENTS, $map);
     }
 
-    protected function filemap(): void
-    {
-        //
-    }
 
+
+    /**
+     * 'Files' in Agorakit.
+     */
     protected function attachments(): void
     {
-        //
+        $map = [
+            'MediaID' => 'id',
+            'ForeignID' => 'parent_id', // @todo !hasDiscussionBody support (ForeignTable)
+            'InsertUserID' => 'user_id',
+            'item_type',
+            'Size' => 'filesize',
+            //'Active' => 'status', // filter required?
+            'Name' =>  'name',
+            'Type' => 'mime',
+            'Path' => 'path',
+            'DateInserted' => 'created_at',
+            //'original_extension'
+            //'original_filename'
+            //'group_id',
+        ];
+        $query = $this->porterQB()->from('Media')->select();
+        $this->import('files', $query, self::SCHEMA_ATTACHMENTS, $map);
     }
 
+    /**
+     * Avatars are auto-detected by filename in Agorakit.
+     */
     protected function avatars(): void
     {
-        //
+        // noop
+    }
+
+    /**
+     * Assign a new location for message file attachments.
+     *
+     * Format: {approot}/storage/app/groups/{group_id}/files/{file_id}/{datestamp}-{originalname}
+     * Use a generic 'imports' folder instead of attempting to divvy by group.
+     * @see self::filemap()
+     * @see self::SUPPORTED [attachmentPath]
+     */
+    protected function mapAttachments(string $fileTarget): int
+    {
+        $rows = 0;
+        $attachments = $this->porterQB()->from('Media')
+            ->select(['MediaID'])
+            ->selectRaw("concat('{$fileTarget}/', Path) as TargetFullPath")
+            ->whereNotNull("Path")
+            ->get();
+        foreach ($attachments as $attachment) {
+            $rows += $this->dbOutput()->affectingStatement("update `PORT_Media`
+                set TargetFullPath = " . $this->dbOutput()->escape($attachment->TargetFullPath) . "
+                where MediaID = {$attachment->MediaID}");
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Assign a new location for user photos / avatars.
+     *
+     * Format: {approot}/storage/app/users/{user_id}/cover.jpg
+     * We cannot convert to .jpg, so reuse existing file extension.
+     * @see self::filemap()
+     * @see self::SUPPORTED [avatarPath]
+     */
+    protected function mapAvatars(string $fileTarget): int
+    {
+        $rows = 0;
+        $avatars = $this->porterQB()->from('User')
+            ->select(['UserID'])
+            ->selectRaw("concat('{$fileTarget}', UserID, '/cover.', SUBSTRING_INDEX(Photo,'.',-1)) 
+                as TargetAvatarFullPath")
+            ->whereNotNull("SourceAvatarFullPath")
+            ->get();
+        foreach ($avatars as $avatar) {
+            $rows += $this->dbOutput()->affectingStatement("update `PORT_User`
+                set TargetAvatarFullPath = " . $this->dbOutput()->escape($avatar->TargetAvatarFullPath) . "
+                where UserID = {$avatar->UserID}");
+        }
+
+        return $rows;
     }
 }

--- a/src/Target/Agorakit.php
+++ b/src/Target/Agorakit.php
@@ -42,10 +42,7 @@ class Agorakit extends Target
         'hasDiscussionBody' => true,
     ];
 
-    /** @var int Offset for inserting OP content into the posts table. */
-    protected int $discussionPostOffset = 0;
-
-    protected const SCHEMA_USER = [
+    protected const SCHEMA_USERS = [
         'id' => 'int',
         'name' => 'varchar(100)',
         'username' => 'varchar(100)',
@@ -90,12 +87,12 @@ class Agorakit extends Target
         'is_restricted' => 'tinyint',
     ];
 
-    protected const SCHEMA_GROUPS = [
+    protected const SCHEMA_ROLES = [
         'id' => 'int',
         'name_singular' => 'varchar(100)',
     ];
 
-    protected const SCHEMA_MEMBERSHIP = [
+    protected const SCHEMA_USER_ROLES = [
         'user_id' => 'int',
         'group_id' => 'int',
     ];
@@ -122,30 +119,30 @@ class Agorakit extends Target
             'Admin' => 'admin',
         ];
         $filters = [];
-        $query = $this->porterQB()
-            ->from('User')
+        $query = $this->porterQB()->from('User')
             ->select();
-
-        $this->import('users', $query, self::SCHEMA_USER, $map, $filters);
+        $this->import('users', $query, self::SCHEMA_USERS, $map, $filters);
     }
 
+    /**
+     * 'Groups' in Agorakit.
+     */
     protected function roles(): void
     {
+        // Roles.
         $map = [];
-        $query = $this->porterQB()
-            ->from('Role')
+        $query = $this->porterQB()->from('Role')
             ->select();
-        $this->import('groups', $query, self::SCHEMA_GROUPS, $map);
+        $this->import('groups', $query, self::SCHEMA_ROLES, $map);
 
         // User Role.
         $map = [
             'UserID' => 'user_id',
             'RoleID' => 'group_id',
         ];
-        $query = $this->porterQB()
-            ->from('UserRole')
+        $query = $this->porterQB()->from('UserRole')
             ->select();
-        $this->import('membership', $query, self::SCHEMA_MEMBERSHIP, $map);
+        $this->import('membership', $query, self::SCHEMA_USER_ROLES, $map);
     }
 
     protected function categories(): void
@@ -161,11 +158,9 @@ class Agorakit extends Target
         $filters = [
             'CountDiscussions' => 'emptyToZero',
         ];
-        $query = $this->porterQB()
-            ->from('Category')
+        $query = $this->porterQB()->from('Category')
             ->select()
             ->where('CategoryID', '!=', -1); // Ignore Vanilla's root category.
-
         $this->import('tags', $query, self::SCHEMA_CATEGORIES, $map, $filters);
     }
 
@@ -187,14 +182,15 @@ class Agorakit extends Target
             //'Announce' => 'status',
             //'Closed' => '',
         ];
-        $filters = [];
-        $query = $this->porterQB()
-            ->from('Discussion')
+        $query = $this->porterQB()->from('Discussion')
             ->select();
 
-        $this->import('discussions', $query, self::SCHEMA_DISCUSSIONS, $map, $filters);
+        $this->import('discussions', $query, self::SCHEMA_DISCUSSIONS, $map);
     }
 
+    /**
+     * 'Posts' in Agorakit,
+     */
     protected function comments(): void
     {
         $map = [
@@ -205,13 +201,26 @@ class Agorakit extends Target
             'DateUpdated' => 'updated_at',
             'Body' => 'body'
         ];
-        $filters = [];
-        $query = $this->porterQB()
-            ->from('Comment')
+        $query = $this->porterQB()->from('Comment')
             ->select();
 
         // @todo !hasDiscussionBody support
 
-        $this->import('posts', $query, self::SCHEMA_COMMENTS, $map, $filters);
+        $this->import('posts', $query, self::SCHEMA_COMMENTS, $map);
+    }
+
+    protected function filemap(): void
+    {
+        //
+    }
+
+    protected function attachments(): void
+    {
+        //
+    }
+
+    protected function avatars(): void
+    {
+        //
     }
 }

--- a/src/Target/Agorakit.php
+++ b/src/Target/Agorakit.php
@@ -6,7 +6,6 @@
 
 namespace Porter\Target;
 
-use Porter\Migration;
 use Porter\Target;
 
 /**
@@ -14,32 +13,28 @@ use Porter\Target;
  */
 class Agorakit extends Target
 {
-    public const SUPPORTED = [
+    public const array SUPPORTED = [
         'name' => 'Agorakit',
         'defaultTablePrefix' => '',
         //'avatarPath' => '',
         //'attachmentPath' => '',
         'features' => [
-            // round 0 - base
             'Users' => 1,
             'Passwords' => 1,
             'Discussions' => 1,
             'Comments' => 1,
-            // round 1 - mash
-            'Categories' => 0, // @todo TAGS
-            'Tags' => 0, // @todo ALSO TAGS
-            'Roles' => 0, // @todo GROUPS
-            'Groups' => 0, // @todo ALSO GROUPS
-            // round 2 - kludge
-            'Avatars' => 0, // @todo FILES
-            'Attachments' => 0, // @todo ALSO FILES
-            'Reactions' => 0, // @todo REACTIONS ???
-            // round 3 - create
-            'Bookmarks' => 0, // @todo no support
-            'Polls' => 0, // @todo no support
-            'Badges' => 0, // @todo no support
-            // round 4 - rethink
-            'PrivateMessages' => 0, // @todo no support
+            'Categories' => 1, // @todo TAGS
+            'Roles' => 1, // @todo GROUPS
+            'Attachments' => 1, // @todo FILES
+            'Avatars' => 1,
+            // @todo Figure out support options.
+            'Tags' => 0,
+            'Groups' => 0,
+            'Reactions' => 0,
+            'Bookmarks' => 0,
+            'Polls' => 0,
+            'Badges' => 0,
+            'PrivateMessages' => 0,
         ]
     ];
 
@@ -51,32 +46,14 @@ class Agorakit extends Target
     protected int $discussionPostOffset = 0;
 
     /**
-     * Main import process.
-     */
-    public function run(Migration $port): void
-    {
-        $this->users($port);
-        $this->roles($port);
-        $this->categories($port);
-
-        $this->discussions($port);
-        $this->comments($port);
-    }
-
-    /**
      * Check for issues that will break the import.
-     *
-     * @param Migration $port
      */
-    public function validate(Migration $port): void
+    public function validate(): void
     {
         //
     }
 
-    /**
-     * @param Migration $port
-     */
-    protected function users(Migration $port): void
+    protected function users(): void
     {
         $structure = [
             'id' => 'int',
@@ -94,35 +71,31 @@ class Agorakit extends Target
             'FullName' => 'name',
             'Email' => 'email',
             'Password' => 'password',
-            'Confirmed' => 'verified',//
+            'Confirmed' => 'verified',
             //'Photo' => 'avatar_url',
             'DateInserted' => 'created_at',
             'Admin' => 'admin',
         ];
         $filters = [];
-        $query = $port->targetQB()
+        $query = $this->porterQB()
             ->from('User')
             ->select();
 
-        $port->import('users', $query, $structure, $map, $filters);
+        $this->import('users', $query, $structure, $map, $filters);
     }
 
-    /**
-     *
-     * @param Migration $port
-     */
-    protected function roles(Migration $port): void
+    protected function roles(): void
     {
         $structure = [
             'id' => 'int',
             'name_singular' => 'varchar(100)',
         ];
         $map = [];
-        $query = $port->targetQB()
+        $query = $this->porterQB()
             ->from('Role')
             ->select();
 
-        $port->import('groups', $query, $structure, $map);
+        $this->import('groups', $query, $structure, $map);
 
         // User Role.
         $structure = [
@@ -133,17 +106,14 @@ class Agorakit extends Target
             'UserID' => 'user_id',
             'RoleID' => 'group_id',
         ];
-        $query = $port->targetQB()
+        $query = $this->porterQB()
             ->from('UserRole')
             ->select();
 
-        $port->import('group_user', $query, $structure, $map);
+        $this->import('group_user', $query, $structure, $map);
     }
 
-    /**
-     * @param Migration $port
-     */
-    protected function categories(Migration $port): void
+    protected function categories(): void
     {
         $structure = [
             'id' => 'int',
@@ -167,18 +137,15 @@ class Agorakit extends Target
         $filters = [
             'CountDiscussions' => 'emptyToZero',
         ];
-        $query = $port->targetQB()
+        $query = $this->porterQB()
             ->from('Category')
             ->select()
             ->where('CategoryID', '!=', -1); // Ignore Vanilla's root category.
 
-        $port->import('tags', $query, $structure, $map, $filters);
+        $this->import('tags', $query, $structure, $map, $filters);
     }
 
-    /**
-     * @param Migration $port
-     */
-    protected function discussions(Migration $port): void
+    protected function discussions(): void
     {
         $structure = [];
         $map = [
@@ -198,17 +165,14 @@ class Agorakit extends Target
             //'Closed' => '',
         ];
         $filters = [];
-        $query = $port->targetQB()
+        $query = $this->porterQB()
             ->from('Discussion')
             ->select();
 
-        $port->import('discussions', $query, $structure, $map, $filters);
+        $this->import('discussions', $query, $structure, $map, $filters);
     }
 
-    /**
-     * @param Migration $port
-     */
-    protected function comments(Migration $port): void
+    protected function comments(): void
     {
         $structure = [];
         $map = [
@@ -220,12 +184,12 @@ class Agorakit extends Target
             'Body' => 'body'
         ];
         $filters = [];
-        $query = $port->targetQB()
+        $query = $this->porterQB()
             ->from('Comment')
             ->select();
 
         // @todo !hasDiscussionBody support
 
-        $port->import('posts', $query, $structure, $map, $filters);
+        $this->import('posts', $query, $structure, $map, $filters);
     }
 }

--- a/src/Target/Agorakit.php
+++ b/src/Target/Agorakit.php
@@ -45,6 +45,61 @@ class Agorakit extends Target
     /** @var int Offset for inserting OP content into the posts table. */
     protected int $discussionPostOffset = 0;
 
+    protected const SCHEMA_USER = [
+        'id' => 'int',
+        'name' => 'varchar(100)',
+        'username' => 'varchar(100)',
+        'email' => 'varchar(100)',
+        'verified' => 'tinyint',
+        'password' => 'varchar(100)',
+        'created_at' => 'datetime',
+        'admin' => 'tinyint',
+    ];
+
+    protected const SCHEMA_DISCUSSIONS = [
+        'id' => 'int',
+        'group_id' => 'int',
+        'user_id' => 'int',
+        'status' => 'int',
+        'name' => 'varchar(100)',
+        'body' => 'text',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+        'deleted_at' => 'datetime',
+        'total_comments' => 'int',
+    ];
+    protected const SCHEMA_COMMENTS = [
+        'id' => 'int',
+        'discussion_id' => 'int',
+        'user_id' => 'int',
+        'body' => 'text',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+        'deleted_at' => 'datetime',
+    ];
+
+    protected const SCHEMA_CATEGORIES = [
+        'id' => 'int',
+        'name' => 'varchar(100)',
+        'slug' => 'varchar(100)',
+        'description' => 'text',
+        'parent_id' => 'int',
+        'position' => 'int',
+        'discussion_count' => 'int',
+        'is_hidden' => 'tinyint',
+        'is_restricted' => 'tinyint',
+    ];
+
+    protected const SCHEMA_GROUPS = [
+        'id' => 'int',
+        'name_singular' => 'varchar(100)',
+    ];
+
+    protected const SCHEMA_MEMBERSHIP = [
+        'user_id' => 'int',
+        'group_id' => 'int',
+    ];
+
     /**
      * Check for issues that will break the import.
      */
@@ -55,16 +110,6 @@ class Agorakit extends Target
 
     protected function users(): void
     {
-        $structure = [
-            'id' => 'int',
-            'name' => 'varchar(100)',
-            'username' => 'varchar(100)',
-            'email' => 'varchar(100)',
-            'verified' => 'tinyint',
-            'password' => 'varchar(100)',
-            'created_at' => 'datetime',
-            'admin' => 'tinyint',
-        ];
         $map = [
             'UserID' => 'id',
             'Name' => 'username',
@@ -81,27 +126,18 @@ class Agorakit extends Target
             ->from('User')
             ->select();
 
-        $this->import('users', $query, $structure, $map, $filters);
+        $this->import('users', $query, self::SCHEMA_USER, $map, $filters);
     }
 
     protected function roles(): void
     {
-        $structure = [
-            'id' => 'int',
-            'name_singular' => 'varchar(100)',
-        ];
         $map = [];
         $query = $this->porterQB()
             ->from('Role')
             ->select();
-
-        $this->import('groups', $query, $structure, $map);
+        $this->import('groups', $query, self::SCHEMA_GROUPS, $map);
 
         // User Role.
-        $structure = [
-            'user_id' => 'int',
-            'group_id' => 'int',
-        ];
         $map = [
             'UserID' => 'user_id',
             'RoleID' => 'group_id',
@@ -109,23 +145,11 @@ class Agorakit extends Target
         $query = $this->porterQB()
             ->from('UserRole')
             ->select();
-
-        $this->import('group_user', $query, $structure, $map);
+        $this->import('membership', $query, self::SCHEMA_MEMBERSHIP, $map);
     }
 
     protected function categories(): void
     {
-        $structure = [
-            'id' => 'int',
-            'name' => 'varchar(100)',
-            'slug' => 'varchar(100)',
-            'description' => 'text',
-            'parent_id' => 'int',
-            'position' => 'int',
-            'discussion_count' => 'int',
-            'is_hidden' => 'tinyint',
-            'is_restricted' => 'tinyint',
-        ];
         $map = [
             'CategoryID' => 'id',
             'Name' => 'name',
@@ -142,12 +166,11 @@ class Agorakit extends Target
             ->select()
             ->where('CategoryID', '!=', -1); // Ignore Vanilla's root category.
 
-        $this->import('tags', $query, $structure, $map, $filters);
+        $this->import('tags', $query, self::SCHEMA_CATEGORIES, $map, $filters);
     }
 
     protected function discussions(): void
     {
-        $structure = [];
         $map = [
             'DiscussionID' => 'id',
             'InsertUserID' => 'user_id',
@@ -169,12 +192,11 @@ class Agorakit extends Target
             ->from('Discussion')
             ->select();
 
-        $this->import('discussions', $query, $structure, $map, $filters);
+        $this->import('discussions', $query, self::SCHEMA_DISCUSSIONS, $map, $filters);
     }
 
     protected function comments(): void
     {
-        $structure = [];
         $map = [
             'CommentID' => 'id',
             'DiscussionID' => 'discussion_id',
@@ -190,6 +212,6 @@ class Agorakit extends Target
 
         // @todo !hasDiscussionBody support
 
-        $this->import('posts', $query, $structure, $map, $filters);
+        $this->import('posts', $query, self::SCHEMA_COMMENTS, $map, $filters);
     }
 }

--- a/src/Target/Agorakit.php
+++ b/src/Target/Agorakit.php
@@ -23,14 +23,14 @@ class Agorakit extends Target
             'Passwords' => 1,
             'Discussions' => 1,
             'Comments' => 1,
-            'Categories' => 1, // @todo TAGS
-            'Roles' => 1, // @todo GROUPS
-            'Attachments' => 1, // @todo FILES
+            'Categories' => 1,
+            'Roles' => 1,
+            'Attachments' => 1,
             'Avatars' => 1,
+            'Reactions' => 0, // Partial
             // @todo Figure out support options.
             'Tags' => 0,
             'Groups' => 0,
-            'Reactions' => 0,
             'Bookmarks' => 0,
             'Polls' => 0,
             'Badges' => 0,
@@ -143,7 +143,6 @@ class Agorakit extends Target
             'Email' => 'email',
             'Password' => 'password',
             'Confirmed' => 'verified',
-            //'Photo' => 'avatar_url',
             'DateInserted' => 'created_at',
             'Admin' => 'admin',
         ];
@@ -203,17 +202,11 @@ class Agorakit extends Target
             'Body' => 'body',
             'DateInserted' => 'created_at',
             'DateUpdated' => 'updated_at',
-            //'FirstCommentID' => 'first_post_id',
-            //'LastCommentID' => 'last_post_id',
-            //'DateLastComment' => 'last_posted_at',
-            //'LastCommentUserID' => 'last_posted_user_id',
             'CountComments' => 'total_comments',
-            //'Announce' => 'status',
-            //'Closed' => '',
+            //'Announce'/'Closed' => 'status',
         ];
         $query = $this->porterQB()->from('Discussion')
             ->select();
-
         $this->import('discussions', $query, self::SCHEMA_DISCUSSIONS, $map);
     }
 
@@ -232,9 +225,6 @@ class Agorakit extends Target
         ];
         $query = $this->porterQB()->from('Comment')
             ->select();
-
-        // @todo !hasDiscussionBody support
-
         $this->import('posts', $query, self::SCHEMA_COMMENTS, $map);
     }
 
@@ -246,7 +236,6 @@ class Agorakit extends Target
     protected function reactions(): void
     {
         $map = [
-            //'id',
             'UserID' => 'user_id',
             'RecordID' => 'reactable_id',
             'RecordType' => 'reactable_type',
@@ -257,7 +246,6 @@ class Agorakit extends Target
             ->leftJoin('Tag t', 't.TagID', '=', 'ut.TagID')
             ->select()
             ->whereIn('ut.RecordType', ['Discussion', 'Comment']);
-
         $this->import('reactions', $query, self::SCHEMA_REACTIONS, $map);
     }
 

--- a/src/Target/Agorakit.php
+++ b/src/Target/Agorakit.php
@@ -116,6 +116,16 @@ class Agorakit extends Target
         'deleted_at' => 'datetime',
     ];
 
+    protected const SCHEMA_REACTIONS = [
+        'id' => 'int',
+        'user_id' => 'int',
+        'reactable_id' => 'int',
+        'reactable_type' => 'varchar(100)',
+        'type' => 'varchar(100)',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
     /**
      * Check for issues that will break the import.
      */
@@ -228,7 +238,28 @@ class Agorakit extends Target
         $this->import('posts', $query, self::SCHEMA_COMMENTS, $map);
     }
 
+    /**
+     * 2026-07
+     * Agorakit only supports a subset of named emoji reactions hard-coded to /images/reactions/{type}.png
+     * so you'd need to pass those files along as well.
+     */
+    protected function reactions(): void
+    {
+        $map = [
+            //'id',
+            'UserID' => 'user_id',
+            'RecordID' => 'reactable_id',
+            'RecordType' => 'reactable_type',
+            'Name' => 'type', // Expects /images/reactions/{filename}.png.
+            'DateInserted' => 'created_at',
+        ];
+        $query = $this->porterQB()->from('UserTag ut')
+            ->leftJoin('Tag t', 't.TagID', '=', 'ut.TagID')
+            ->select()
+            ->whereIn('ut.RecordType', ['Discussion', 'Comment']);
 
+        $this->import('reactions', $query, self::SCHEMA_REACTIONS, $map);
+    }
 
     /**
      * 'Files' in Agorakit.
@@ -237,9 +268,9 @@ class Agorakit extends Target
     {
         $map = [
             'MediaID' => 'id',
-            'ForeignID' => 'parent_id', // @todo !hasDiscussionBody support (ForeignTable)
+            'ForeignID' => 'parent_id',
             'InsertUserID' => 'user_id',
-            'item_type',
+            'ForeignTable' => 'item_type',
             'Size' => 'filesize',
             //'Active' => 'status', // filter required?
             'Name' =>  'name',

--- a/src/Target/Flarum.php
+++ b/src/Target/Flarum.php
@@ -50,11 +50,50 @@ class Flarum extends Target
         'fileTransferSupport' => true,
     ];
 
+    protected const SCHEMA_USERS = [
+        'id' => 'int',
+        'username' => 'varchar(100)',
+        'email' => 'varchar(100)',
+        'is_email_confirmed' => 'tinyint',
+        'password' => 'varchar(100)',
+        'avatar_url' => 'varchar(100)',
+        'joined_at' => 'datetime',
+        'last_seen_at' => 'datetime',
+        'discussion_count' => 'int',
+        'comment_count' => 'int',
+    ];
+
+    protected const SCHEMA_ROLES = [
+        'id' => 'int',
+        'name_singular' => 'varchar(100)',
+        'name_plural' => 'varchar(100)',
+        'color' => 'varchar(20)',
+        'icon' => 'varchar(100)',
+        'is_hidden' => 'tinyint',
+    ];
+
+    protected const SCHEMA_USER_ROLES = [
+        'user_id' => 'int',
+        'group_id' => 'int',
+    ];
+
+    protected const SCHEMA_CATEGORIES = [
+        'id' => 'int',
+        'name' => 'varchar(100)',
+        'slug' => 'varchar(100)',
+        'description' => 'text',
+        'parent_id' => 'int',
+        'position' => 'int',
+        'discussion_count' => 'int',
+        'is_hidden' => 'tinyint',
+        'is_restricted' => 'tinyint',
+    ];
+
     /**
      * @var array Table structure for `posts`.
      * @see \Porter\Postscript\Flarum::numberPosts() for 'keys' requirement.
      */
-    protected const DB_STRUCTURE_POSTS = [
+    protected const SCHEMA_POSTS = [
         'id' => 'int',
         'discussion_id' => 'int',
         'user_id' => 'int',
@@ -80,7 +119,7 @@ class Flarum extends Target
      * @var array Table structure for 'discussions`.
      * @see \Porter\Postscript\Flarum::numberPosts() for 'keys' requirement.
      */
-    protected const DB_STRUCTURE_DISCUSSIONS = [
+    protected const SCHEMA_DISCUSSIONS = [
         'id' => 'int',
         'user_id' => 'int',
         'title' => 'varchar(200)',
@@ -106,6 +145,105 @@ class Flarum extends Target
         ],
     ];
 
+    protected const SCHEMA_DISCUSSION_TAGS = [
+        'discussion_id' => 'int',
+        'tag_id' => 'int',
+    ];
+
+    protected const SCHEMA_BOOKMARKS = [
+        'discussion_id' => 'int',
+        'user_id' => 'int',
+        'last_read_at' => 'datetime',
+        'subscription' => [null, 'follow', 'ignore'],
+        'last_read_post_number' => 'int',
+        'keys' => [
+            'FLA_discussion_user_discussion_id_foreign' => [
+                'type' => 'index',
+                'columns' => ['discussion_id'],
+            ],
+        ],
+    ];
+
+    protected const SCHEMA_ATTACHMENTS = [
+        'id' => 'int',
+        'actor_id' => 'int',
+        'discussion_id' => 'int',
+        'post_id' => 'int',
+        'base_name' => 'varchar(255)', // "download as"
+        'path' => 'varchar(255)', // from /forumroot/assets/files
+        'url' => 'varchar(255)',
+        'type' => 'varchar(255)', // MIME
+        'size'  => 'int', // bytes
+        'created_at' => 'datetime',
+        'upload_method' => 'varchar(255)', // Probably just 'local'
+        'tag' => 'varchar(255)', // Required; generates preview in Profile -> "My Media"
+    ];
+
+    protected const SCHEMA_BADGES = [
+        'id' => 'int',
+        'name' => 'varchar(200)',
+        'image' => 'text',
+        'description' => 'text',
+        'badge_category_id' => 'int',
+        'points' => 'int',
+        'created_at' => 'datetime',
+        'is_visible' => 'tinyint',
+    ];
+
+    protected const SCHEMA_USER_BADGES = [
+        'badge_id' => 'int',
+        'user_id' => 'int',
+        'assigned_at' => 'datetime',
+        'description' => 'text',
+    ];
+
+    protected const SCHEMA_REACTIONS = [
+        'id' => 'int',
+        'identifier' => 'varchar(200)',
+        'type' => 'varchar(200)',
+        'enabled' => 'tinyint',
+        'display' => 'varchar(200)',
+    ];
+
+    protected const SCHEMA_POST_REACTIONS = [
+        'id' => 'int',
+        'post_id' => 'int',
+        'user_id' => 'int',
+        'reaction_id' => 'int',
+        'created_at' => 'timestamp',
+        'updated_at' => 'timestamp',
+    ];
+
+    protected const SCHEMA_POLLS = [
+        'id' => 'int',
+        'question' => 'varchar(200)',
+        'discussion_id' => 'int',
+        'user_id' => 'int',
+        'public_poll' => 'tinyint', // Map to "Anonymous" somehow?
+        'end_date' => 'datetime', // Using date created here will close all polls, but work fine.
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+        'vote_count' => 'int',
+    ];
+
+    protected const SCHEMA_POLL_OPTIONS = [
+        'id' => 'int',
+        'answer' => 'varchar(200)',
+        'poll_id' => 'int',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+        'vote_count' => 'int',
+    ];
+
+    protected const SCHEMA_POLL_VOTES = [
+            //id
+            'poll_id' => 'int',
+            'option_id' => 'int',
+            'user_id' => 'int',
+            'created_at' => 'timestamp',
+            'updated_at' => 'timestamp',
+        ];
+
     /** @var int Offset for inserting OP content into the posts table. */
     protected int $discussionPostOffset = 0;
 
@@ -120,38 +258,9 @@ class Flarum extends Target
      */
     public function validate(): void
     {
-        $this->uniqueUserNames();
-        $this->uniqueUserEmails();
-    }
-
-    /**
-     * @return array
-     */
-    protected function getStructureDiscussions()
-    {
-        $structure = self::DB_STRUCTURE_DISCUSSIONS;
-        // fof/gamification — no data, just prevent failure (no default values are set)
-        if ($this->hasOutputSchema('discussions', ['votes'])) {
-            $structure['votes'] = 'int';
-            $structure['hotness'] = 'double';
-        }
-        if ($this->hasOutputSchema('discussions', ['view_count'])) {
-            $structure['view_count'] = 'int'; // flarumite/simple-discussion-views
-        }
-        return $structure;
-    }
-
-    /**
-     * Flarum must have unique usernames. Report users skipped (because of `insert ignore`).
-     *
-     * Unsure this could get automated fix. You'd have to determine which has/have data attached and possibly merge.
-     * You'd also need more data from findDuplicates, especially the IDs.
-     * Folks are just gonna need to manually edit their existing forum data for now to rectify dupe issues.
-     *
-     * @throws \Exception
-     */
-    public function uniqueUserNames(): void
-    {
+        // Flarum must have unique usernames. Report users skipped (because of `insert ignore`).
+        // Unsure fix could be automated. Manually edit existing forum data for now to rectify dupe issues.
+        // Would need to find data attached & possibly merge. Would need IDs etc from findDuplicates().
         $allowlist = [
             '[Deleted User]',
             '[DeletedUser]',
@@ -163,70 +272,51 @@ class Flarum extends Target
         if (!empty($dupes)) {
             Log::comment('DATA LOSS! Users skipped for duplicate user.name: ' . implode(', ', $dupes));
         }
-    }
 
-    /**
-     * Flarum must have unique emails. Report users skipped (because of `insert ignore`).
-     *
-     * @throws \Exception
-     * @see uniqueUserNames
-     *
-     */
-    public function uniqueUserEmails(): void
-    {
+        // Flarum must have unique emails. Report users skipped (because of `insert ignore`).
         $dupes = $this->findDuplicates('User', 'Email');
         if (!empty($dupes)) {
             Log::comment('DATA LOSS! Users skipped for duplicate user.email: ' . implode(', ', $dupes));
         }
     }
 
-    /**
-     * Main import process.
-     */
-    public function run(): void
+    protected function setup(): void
     {
         // Ignore constraints on tables that block import.
         $this->ignoreOutputDuplicates('users');
+    }
 
-        // Map a file transfer.
-        $this->mapFileTransfer();
+    protected function precontent(): void
+    {
+        // Singleton factory; depends on Users being done.
+        Formatter::instance()->buildUserMap($this);
+    }
 
-        $this->users();
-        $this->roles(); // 'Groups' in Flarum
-        $this->categories(); // 'Tags' in Flarum
+    /**
+     * Duplicated logic between discussions() and privateMessages() for Flarum plugin reasons.
+     */
+    protected function getDiscussionSchema(): array
+    {
+        $structure = self::SCHEMA_DISCUSSIONS;
 
-        // Singleton factory; big timing issue; depends on Users being done.
-        Formatter::instance()->buildUserMap($this); // @todo Hook for pre-UGC import?
+        // fof/gamification — no data, just prevent failure (no default values are set)
+        if ($this->hasOutputSchema('discussions', ['votes'])) {
+            $structure['votes'] = 'int';
+            $structure['hotness'] = 'double';
+        }
 
-        $this->discussions();
-        $this->bookmarks(); // Requires addon `flarum/subscriptions`
-        $this->comments(); // 'Posts' in Flarum
+        // flarumite/simple-discussion-views
+        if ($this->hasOutputSchema('discussions', ['view_count'])) {
+            $structure['view_count'] = 'int';
+        }
 
-        $this->badges(); // Requires addon `17development/flarum-user-badges`
-        $this->polls(); // Requires addon `fof/pollsx`
-        $this->reactions(); // Requires addon `fof/reactions`
-
-        $this->privateMessages(); // Requires addon `fof/byobu`
-
-        $this->attachments(); // Requires discussions, comments, and PMs have imported.
+        return $structure;
     }
 
     /**
      */
     protected function users(): void
     {
-        $structure = [
-            'id' => 'int',
-            'username' => 'varchar(100)',
-            'email' => 'varchar(100)',
-            'is_email_confirmed' => 'tinyint',
-            'password' => 'varchar(100)',
-            'avatar_url' => 'varchar(100)',
-            'joined_at' => 'datetime',
-            'last_seen_at' => 'datetime',
-            'discussion_count' => 'int',
-            'comment_count' => 'int',
-        ];
         $map = [
             'UserID' => 'id',
             'Name' => 'username',
@@ -247,11 +337,11 @@ class Flarum extends Target
             ->select()
             ->selectRaw('COALESCE(Confirmed, 1) as is_email_confirmed'); // Cannot be null.
 
-        $this->import('users', $query, $structure, $map, $filters);
+        $this->import('users', $query, self::SCHEMA_USERS, $map, $filters);
     }
 
     /**
-     * Flarum handles role assignment in a magic way.
+     * 'Groups' in Flarum. Flarum handles role assignment in a magic way.
      *
      * This compensates by shifting all RoleIDs +4, rendering any old 'Member' or 'Guest' role useless & deprecated.
      * @see https://docs.flarum.org/extend/permissions/
@@ -259,27 +349,18 @@ class Flarum extends Target
      */
     protected function roles(): void
     {
-        $structure = [
-            'id' => 'int',
-            'name_singular' => 'varchar(100)',
-            'name_plural' => 'varchar(100)',
-            'color' => 'varchar(20)',
-            'icon' => 'varchar(100)',
-            'is_hidden' => 'tinyint',
-        ];
-        $map = [];
-
         // Verify support.
         if (!$this->hasPortSchema('UserRole')) {
             Log::comment('Skipping import: Roles (Source lacks support)');
-            $this->importEmpty('groups', $structure);
-            $this->importEmpty('group_user', $structure);
+            $this->importEmpty('groups', self::SCHEMA_ROLES);
+            $this->importEmpty('group_user', self::SCHEMA_ROLES);
             return;
         }
 
         // Delete orphaned user role associations (deleted users).
         $this->pruneOrphanedRecords('UserRole', 'UserID', 'User', 'UserID');
 
+        // Roles.
         $query = $this->porterQB()
             ->from('Role')
             // Flarum reserves 1-3 & uses 4 for mods by default.
@@ -289,14 +370,9 @@ class Flarum extends Target
             ->selectRaw('COALESCE(Name, CONCAT("role", RoleID)) as name_plural') // Cannot be null.
             // Hiding roles is an uncommon feature; hide none.
             ->selectRaw('0 as is_hidden');
+        $this->import('groups', $query, self::SCHEMA_ROLES);
 
-        $this->import('groups', $query, $structure, $map);
-
-        // User Role.
-        $structure = [
-            'user_id' => 'int',
-            'group_id' => 'int',
-        ];
+        // User Roles.
         $map = [
             'UserID' => 'user_id',
             'RoleID' => 'group_id',
@@ -305,25 +381,14 @@ class Flarum extends Target
             ->from('UserRole')
             ->select()
             ->selectRaw("(RoleID + 4) as RoleID"); // Match above offset
-
-        $this->import('group_user', $query, $structure, $map);
+        $this->import('group_user', $query, self::SCHEMA_USER_ROLES, $map);
     }
 
     /**
+     * 'Tags' in Flarum.
      */
     protected function categories(): void
     {
-        $structure = [
-            'id' => 'int',
-            'name' => 'varchar(100)',
-            'slug' => 'varchar(100)',
-            'description' => 'text',
-            'parent_id' => 'int',
-            'position' => 'int',
-            'discussion_count' => 'int',
-            'is_hidden' => 'tinyint',
-            'is_restricted' => 'tinyint',
-        ];
         $map = [
             'CategoryID' => 'id',
             'Name' => 'name',
@@ -345,14 +410,15 @@ class Flarum extends Target
             ->selectRaw("0 as is_restricted")
             ->where('CategoryID', '!=', -1); // Ignore Vanilla's root category.
 
-        $this->import('tags', $query, $structure, $map, $filters);
+        $this->import('tags', $query, self::SCHEMA_CATEGORIES, $map, $filters);
     }
 
     /**
+     * Schema is variable depending on plugins.
      */
     protected function discussions(): void
     {
-        $structure = $this->getStructureDiscussions();
+        $structure = $this->getDiscussionSchema(); // @see self::privateMessages()
         $map = [
             'DiscussionID' => 'id',
             'InsertUserID' => 'user_id',
@@ -392,11 +458,7 @@ class Flarum extends Target
 
         $this->import('discussions', $query, $structure, $map, $filters);
 
-        // Flarum has a separate pivot table for discussion tags.
-        $structure = [
-            'discussion_id' => 'int',
-            'tag_id' => 'int',
-        ];
+        // Discussion Tags pivot table.
         $map = [
             'DiscussionID' => 'discussion_id',
             'CategoryID' => 'tag_id',
@@ -413,11 +475,11 @@ class Flarum extends Target
                     ->leftJoin('Category', 'Discussion.CategoryID', '=', 'Category.CategoryID')
                     ->whereNotNull('ParentCategoryID')
             );
-
-        $this->import('discussion_tag', $query, $structure, $map, $filters);
+        $this->import('discussion_tag', $query, self::SCHEMA_DISCUSSION_TAGS, $map, $filters);
     }
 
     /**
+     * Requires addon `flarum/subscriptions`
      */
     protected function bookmarks(): void
     {
@@ -427,19 +489,6 @@ class Flarum extends Target
             return;
         }
 
-        $structure = [
-            'discussion_id' => 'int',
-            'user_id' => 'int',
-            'last_read_at' => 'datetime',
-            'subscription' => [null, 'follow', 'ignore'],
-            'last_read_post_number' => 'int',
-            'keys' => [
-                'FLA_discussion_user_discussion_id_foreign' => [
-                    'type' => 'index',
-                    'columns' => ['discussion_id'],
-                ],
-            ],
-        ];
         $map = [
             'DiscussionID' => 'discussion_id',
             'UserID' => 'user_id',
@@ -451,10 +500,11 @@ class Flarum extends Target
             ->selectRaw("if (Bookmarked > 0, 'follow', null) as subscription")
             ->where('UserID', '>', 0); // Vanilla can have zeroes here, can't remember why.
 
-        $this->import('discussion_user', $query, $structure, $map);
+        $this->import('discussion_user', $query, self::SCHEMA_BOOKMARKS, $map);
     }
 
     /**
+     * 'Posts' in Flarum.
      */
     protected function comments(): void
     {
@@ -514,14 +564,14 @@ class Flarum extends Target
             $query->union($discussions);
         }
 
-        $this->import('posts', $query, self::DB_STRUCTURE_POSTS, $map, $filters);
+        $this->import('posts', $query, self::SCHEMA_POSTS, $map, $filters);
     }
 
     /**
      * Currently discards thumbnails because Flarum's extension doesn't have any.
      *
+     * Requires discussions, comments, and PMs have imported.
      * @todo Support for `fof_upload_files.discussion_id` field, likely in Postscript (it's derived data).
-     *
      */
     protected function attachments(): void
     {
@@ -531,20 +581,6 @@ class Flarum extends Target
             return;
         }
 
-        $structure = [
-            'id' => 'int',
-            'actor_id' => 'int',
-            'discussion_id' => 'int',
-            'post_id' => 'int',
-            'base_name' => 'varchar(255)', // "download as"
-            'path' => 'varchar(255)', // from /forumroot/assets/files
-            'url' => 'varchar(255)',
-            'type' => 'varchar(255)', // MIME
-            'size'  => 'int', // bytes
-            'created_at' => 'datetime',
-            'upload_method' => 'varchar(255)', // Probably just 'local'
-            'tag' => 'varchar(255)', // Required; generates preview in Profile -> "My Media"
-        ];
         $map = [
             'MediaID' => 'id',
             'Name' => 'base_name',
@@ -578,10 +614,11 @@ class Flarum extends Target
                 else 'file'
                 end as tag");
 
-        $this->import('fof_upload_files', $query, $structure, $map);
+        $this->import('fof_upload_files', $query, self::SCHEMA_ATTACHMENTS, $map);
     }
 
     /**
+     * Requires addon `17development/flarum-user-badges`.
      */
     protected function badges(): void
     {
@@ -595,16 +632,6 @@ class Flarum extends Target
         // One category is added in postscript.
 
         // Badges
-        $structure = [
-            'id' => 'int',
-            'name' => 'varchar(200)',
-            'image' => 'text',
-            'description' => 'text',
-            'badge_category_id' => 'int',
-            'points' => 'int',
-            'created_at' => 'datetime',
-            'is_visible' => 'tinyint',
-        ];
         $map = [
             'Name' => 'name',
             'BadgeID' => 'id',
@@ -620,15 +647,9 @@ class Flarum extends Target
             ->select()
             ->selectRaw('1 as badge_category_id');
 
-        $this->import('badges', $query, $structure, $map);
+        $this->import('badges', $query, self::SCHEMA_BADGES, $map);
 
         // User Badges
-        $structure = [
-            'badge_id' => 'int',
-            'user_id' => 'int',
-            'assigned_at' => 'datetime',
-            'description' => 'text',
-        ];
         $map = [
             'BadgeID' => 'badge_id',
             'UserID' => 'user_id',
@@ -637,10 +658,11 @@ class Flarum extends Target
         ];
         $query = $this->porterQB()->from('UserBadge')->select('*');
 
-        $this->import('badge_user', $query, $structure, $map);
+        $this->import('badge_user', $query, self::SCHEMA_USER_BADGES, $map);
     }
 
     /**
+     * Requires addon `fof/pollsx`.
      */
     protected function polls(): void
     {
@@ -651,17 +673,6 @@ class Flarum extends Target
         }
 
         // Polls
-        $structure = [
-            'id' => 'int',
-            'question' => 'varchar(200)',
-            'discussion_id' => 'int',
-            'user_id' => 'int',
-            'public_poll' => 'tinyint', // Map to "Anonymous" somehow?
-            'end_date' => 'datetime', // Using date created here will close all polls, but work fine.
-            'created_at' => 'datetime',
-            'updated_at' => 'datetime',
-            'vote_count' => 'int',
-        ];
         $map = [
             'PollID' => 'id',
             'Name' => 'question',
@@ -676,18 +687,9 @@ class Flarum extends Target
             ->select('DateInserted as end_date')
                 // Whether its public or anonymous are inverse conditions, so flip the value.
             ->selectRaw('if(Anonymous>0, 0, 1) as public_poll');
-
-        $this->import('polls', $query, $structure, $map);
+        $this->import('polls', $query, self::SCHEMA_POLLS, $map);
 
         // Poll Options
-        $structure = [
-            'id' => 'int',
-            'answer' => 'varchar(200)',
-            'poll_id' => 'int',
-            'created_at' => 'datetime',
-            'updated_at' => 'datetime',
-            'vote_count' => 'int',
-        ];
         $map = [
             'PollOptionID' => 'id',
             'PollID' => 'poll_id',
@@ -697,18 +699,9 @@ class Flarum extends Target
             'CountVotes' => 'vote_count',
         ];
         $query = $this->porterQB()->from('PollOption')->select('*');
-
-        $this->import('poll_options', $query, $structure, $map);
+        $this->import('poll_options', $query, self::SCHEMA_POLL_OPTIONS, $map);
 
         // Poll Votes
-        $structure = [
-            //id
-            'poll_id' => 'int',
-            'option_id' => 'int',
-            'user_id' => 'int',
-            'created_at' => 'timestamp',
-            'updated_at' => 'timestamp',
-        ];
         $map = [
             'PollOptionID' => 'option_id',
             'UserID' => 'user_id',
@@ -719,11 +712,11 @@ class Flarum extends Target
                 'PollOption.PollID as poll_id',
                 'PollOption.DateInserted as created_at', // Total hack for approximate vote dates.
                 'PollOption.DateUpdated as updated_at']);
-
-        $this->import('poll_votes', $query, $structure, $map);
+        $this->import('poll_votes', $query, self::SCHEMA_POLL_VOTES, $map);
     }
 
     /**
+     * Requires addon `fof/reactions`.
      */
     public function reactions(): void
     {
@@ -734,13 +727,6 @@ class Flarum extends Target
         }
 
         // Reaction Types
-        $structure = [
-            'id' => 'int',
-            'identifier' => 'varchar(200)',
-            'type' => 'varchar(200)',
-            'enabled' => 'tinyint',
-            'display' => 'varchar(200)',
-        ];
         $map = [
             'TagID' => 'id',
             'Name' => 'identifier',
@@ -750,18 +736,9 @@ class Flarum extends Target
             // @todo Setting type='emoji' is a kludge since it won't render Vanilla defaults that way.
             ->select('*')
             ->selectRaw('"emoji" as type');
-
-        $this->import('reactions', $query, $structure, $map);
+        $this->import('reactions', $query, self::SCHEMA_REACTIONS, $map);
 
         // Post Reactions
-        $structure = [
-            'id' => 'int',
-            'post_id' => 'int',
-            'user_id' => 'int',
-            'reaction_id' => 'int',
-            'created_at' => 'timestamp',
-            'updated_at' => 'timestamp',
-        ];
         $map = [
             'RecordID' => 'post_id',
             'UserID' => 'user_id',
@@ -797,12 +774,12 @@ class Flarum extends Target
             $query->union($discussionReactions);
         }
 
-        $this->import('post_reactions', $query, $structure, $map);
+        $this->import('post_reactions', $query, self::SCHEMA_POST_REACTIONS, $map);
     }
 
     /**
+     * Requires addon `fof/byobu`.
      * Export PMs to fof/byobu format, which uses the `posts` & `discussions` tables.
-     *
      */
     protected function privateMessages(): void
     {
@@ -821,7 +798,7 @@ class Flarum extends Target
         // Messages — Discussions
         $MaxDiscussionID = $this->messageDiscussionOffset = $this->getMaxValue('id', 'discussions');
         Log::comment('Discussions offset for PMs is ' . $MaxDiscussionID);
-        $structure = $this->getStructureDiscussions();
+        $structure = $this->getDiscussionSchema();
         $map = [
             'InsertUserID' => 'user_id',
             'DateInserted' => 'created_at',
@@ -868,7 +845,7 @@ class Flarum extends Target
             ->selectRaw('1 as is_private')
             ->selectRaw('"comment" as type');
 
-        $this->import('posts', $query, self::DB_STRUCTURE_POSTS, $map, $filters);
+        $this->import('posts', $query, self::SCHEMA_POSTS, $map, $filters);
 
         // Recipients
         $structure = [
@@ -897,7 +874,7 @@ class Flarum extends Target
      * Set PORT_Media.TargetFullPath and PORT_User.TargetAvatarFullPath
      *
      */
-    public function mapFileTransfer(): void
+    public function filemap(): void
     {
         // Abort if we lack support.
         if (!$this->getFileTransferSupport()) {

--- a/src/Target/Flarum.php
+++ b/src/Target/Flarum.php
@@ -860,40 +860,11 @@ class Flarum extends Target
     }
 
     /**
-     * Setup the destination values for FileTransfer.
-     *
-     * Set PORT_Media.TargetFullPath and PORT_User.TargetAvatarFullPath
-     *
-     */
-    public function filemap(): void
-    {
-        // Abort if we lack support.
-        if (!$this->getFileTransferSupport()) {
-            return;
-        }
-
-        // Map attachments.
-        if ($fileTarget = $this->getPath('attachment', 'full')) {
-            $this->mapAttachments($fileTarget);
-        }
-
-        // Map avatars.
-        if ($fileTarget = $this->getPath('avatar', 'full')) {
-            $this->mapAvatars($fileTarget);
-        }
-    }
-
-    /**
      * Use Media.Path to set Media.TargetFullPath.
      */
-    protected function mapAttachments(string $fileTarget): void
+    protected function mapAttachments(string $fileTarget): int
     {
-        // Start timer.
-        $start = microtime(true);
         $rows = 0;
-        Log::comment("Mapping attachments...");
-
-        // Query & update.
         $attachments = $this->porterQB()->from('Media')
             ->select(['MediaID'])
             // Reuse the filename in `Path` (not `Name`) in case it's been made guaranteed-unique.
@@ -901,54 +872,33 @@ class Flarum extends Target
             // Assume we want the final Path if we got this far, so fix it.
             ->whereNotNull("Path")
             ->get();
-        $memory = memory_get_usage();
         foreach ($attachments as $attachment) {
             $rows += $this->dbOutput()->affectingStatement("update `PORT_Media`
                 set TargetFullPath = " . $this->dbOutput()->escape($attachment->TargetFullPath) . "
                 where MediaID = {$attachment->MediaID}");  // @todo index needed?
         }
 
-        // Report.
-        Log::storage(
-            'map',
-            'Media.TargetFullPath',
-            microtime(true) - $start,
-            $rows,
-            $memory
-        );
+        return $rows;
     }
 
     /**
      * Use User.Photo to set Media.TargetAvatarFullPath.
      */
-    protected function mapAvatars(string $fileTarget): void
+    protected function mapAvatars(string $fileTarget): int
     {
-        // Start timer.
-        $start = microtime(true);
         $rows = 0;
-        Log::comment("Mapping avatars...");
-
-        // Query & update.
         $avatars = $this->porterQB()->from('User')
             ->select(['UserID'])
             ->selectRaw("concat('{$fileTarget}', Photo) as TargetAvatarFullPath")
             // Local-file Photo should begin with a slash.
             ->whereNotNull("SourceAvatarFullPath") // 'Photo' could be a URL otherwise.
             ->get();
-        $memory = memory_get_usage();
         foreach ($avatars as $avatar) {
             $rows += $this->dbOutput()->affectingStatement("update `PORT_User`
                     set TargetAvatarFullPath = " . $this->dbOutput()->escape($avatar->TargetAvatarFullPath) . "
                     where UserID = {$avatar->UserID}"); // @todo index needed?
         }
 
-        // Report.
-        Log::storage(
-            'map',
-            'User.TargetAvatarFullPath',
-            microtime(true) - $start,
-            $rows,
-            $memory
-        );
+        return $rows;
     }
 }

--- a/src/Target/Flarum.php
+++ b/src/Target/Flarum.php
@@ -872,63 +872,83 @@ class Flarum extends Target
             return;
         }
 
+        // Map attachments.
+        if ($fileTarget = $this->getPath('attachment', 'full')) {
+            $this->mapAttachments($fileTarget);
+        }
+
+        // Map avatars.
+        if ($fileTarget = $this->getPath('avatar', 'full')) {
+            $this->mapAvatars($fileTarget);
+        }
+    }
+
+    /**
+     * Use Media.Path to set Media.TargetFullPath.
+     */
+    protected function mapAttachments(string $fileTarget): void
+    {
         // Start timer.
         $start = microtime(true);
         $rows = 0;
         Log::comment("Mapping attachments...");
 
-        // Media.Path
-        if ($fileTarget = $this->getPath('attachment', 'full')) {
-            $attachments = $this->porterQB()->from('Media')
-                ->select(['MediaID'])
-                // Reuse the filename in `Path` (not `Name`) in case it's been made guaranteed-unique.
-                ->selectRaw("concat('{$fileTarget}/', Path) as TargetFullPath")
-                // Assume we want the final Path if we got this far, so fix it.
-                ->whereNotNull("Path")
-                ->get();
-            $memory = memory_get_usage();
-            foreach ($attachments as $attachment) {
-                $rows += $this->dbOutput()->affectingStatement("update `PORT_Media`
-                    set TargetFullPath = " . $this->dbOutput()->escape($attachment->TargetFullPath) . "
-                    where MediaID = {$attachment->MediaID}");  // @todo index needed?
-            }
-            // Report.
-            Log::storage(
-                'map',
-                'Media.TargetFullPath',
-                microtime(true) - $start,
-                $rows,
-                $memory
-            );
+        // Query & update.
+        $attachments = $this->porterQB()->from('Media')
+            ->select(['MediaID'])
+            // Reuse the filename in `Path` (not `Name`) in case it's been made guaranteed-unique.
+            ->selectRaw("concat('{$fileTarget}/', Path) as TargetFullPath")
+            // Assume we want the final Path if we got this far, so fix it.
+            ->whereNotNull("Path")
+            ->get();
+        $memory = memory_get_usage();
+        foreach ($attachments as $attachment) {
+            $rows += $this->dbOutput()->affectingStatement("update `PORT_Media`
+                set TargetFullPath = " . $this->dbOutput()->escape($attachment->TargetFullPath) . "
+                where MediaID = {$attachment->MediaID}");  // @todo index needed?
         }
 
+        // Report.
+        Log::storage(
+            'map',
+            'Media.TargetFullPath',
+            microtime(true) - $start,
+            $rows,
+            $memory
+        );
+    }
+
+    /**
+     * Use User.Photo to set Media.TargetAvatarFullPath.
+     */
+    protected function mapAvatars(string $fileTarget): void
+    {
         // Start timer.
         $start = microtime(true);
         $rows = 0;
         Log::comment("Mapping avatars...");
 
-        // User.Photo
-        if ($fileTarget = $this->getPath('avatar', 'full')) {
-            $avatars = $this->porterQB()->from('User')
-                ->select(['UserID'])
-                ->selectRaw("concat('{$fileTarget}', Photo) as TargetAvatarFullPath")
-                    // Local-file Photo should begin with a slash.
-                ->whereNotNull("SourceAvatarFullPath") // 'Photo' could be a URL otherwise.
-                ->get();
-            $memory = memory_get_usage();
-            foreach ($avatars as $avatar) {
-                $rows += $this->dbOutput()->affectingStatement("update `PORT_User`
+        // Query & update.
+        $avatars = $this->porterQB()->from('User')
+            ->select(['UserID'])
+            ->selectRaw("concat('{$fileTarget}', Photo) as TargetAvatarFullPath")
+            // Local-file Photo should begin with a slash.
+            ->whereNotNull("SourceAvatarFullPath") // 'Photo' could be a URL otherwise.
+            ->get();
+        $memory = memory_get_usage();
+        foreach ($avatars as $avatar) {
+            $rows += $this->dbOutput()->affectingStatement("update `PORT_User`
                     set TargetAvatarFullPath = " . $this->dbOutput()->escape($avatar->TargetAvatarFullPath) . "
                     where UserID = {$avatar->UserID}"); // @todo index needed?
-            }
-            // Report.
-            Log::storage(
-                'map',
-                'User.TargetAvatarFullPath',
-                microtime(true) - $start,
-                $rows,
-                $memory
-            );
         }
+
+        // Report.
+        Log::storage(
+            'map',
+            'User.TargetAvatarFullPath',
+            microtime(true) - $start,
+            $rows,
+            $memory
+        );
     }
 }

--- a/src/Target/Flarum.php
+++ b/src/Target/Flarum.php
@@ -332,8 +332,7 @@ class Flarum extends Target
             'Name' => 'fixDuplicateDeletedNames',
             'Email' => 'fixNullEmails',
         ];
-        $query = $this->porterQB()
-            ->from('User')
+        $query = $this->porterQB()->from('User')
             ->select()
             ->selectRaw('COALESCE(Confirmed, 1) as is_email_confirmed'); // Cannot be null.
 
@@ -361,8 +360,7 @@ class Flarum extends Target
         $this->pruneOrphanedRecords('UserRole', 'UserID', 'User', 'UserID');
 
         // Roles.
-        $query = $this->porterQB()
-            ->from('Role')
+        $query = $this->porterQB()->from('Role')
             // Flarum reserves 1-3 & uses 4 for mods by default.
             ->selectRaw("(RoleID + 4) as id")
             // Singular vs plural is an uncommon feature; don't guess at it, just duplicate the Name.
@@ -377,8 +375,7 @@ class Flarum extends Target
             'UserID' => 'user_id',
             'RoleID' => 'group_id',
         ];
-        $query = $this->porterQB()
-            ->from('UserRole')
+        $query = $this->porterQB()->from('UserRole')
             ->select()
             ->selectRaw("(RoleID + 4) as RoleID"); // Match above offset
         $this->import('group_user', $query, self::SCHEMA_USER_ROLES, $map);
@@ -400,8 +397,7 @@ class Flarum extends Target
         $filters = [
             'CountDiscussions' => 'emptyToZero',
         ];
-        $query = $this->porterQB()
-            ->from('Category')
+        $query = $this->porterQB()->from('Category')
             ->select()
             ->selectRaw('COALESCE(Name, CONCAT("category", CategoryID)) as name') // Cannot be null.
             ->selectRaw('COALESCE(UrlCode, CategoryID) as slug') // Cannot be null.
@@ -446,8 +442,7 @@ class Flarum extends Target
         }
 
         // CountComments needs to be double-mapped so it's included as an alias also.
-        $query = $this->porterQB()
-            ->from('Discussion')
+        $query = $this->porterQB()->from('Discussion')
             ->select()
             ->selectRaw('COALESCE(CountComments, 0) as post_number_index')
             ->selectRaw('DiscussionID as slug')
@@ -463,8 +458,7 @@ class Flarum extends Target
             'DiscussionID' => 'discussion_id',
             'CategoryID' => 'tag_id',
         ];
-        $query = $this->porterQB()
-            ->from('Discussion')
+        $query = $this->porterQB()->from('Discussion')
             ->select(['DiscussionID', 'CategoryID'])
             ->union(
                 // Also tag discussion with the parent category.
@@ -494,8 +488,7 @@ class Flarum extends Target
             'UserID' => 'user_id',
             'DateLastViewed' => 'last_read_at',
         ];
-        $query = $this->porterQB()
-            ->from('UserDiscussion')
+        $query = $this->porterQB()->from('UserDiscussion')
             ->select()
             ->selectRaw("if (Bookmarked > 0, 'follow', null) as subscription")
             ->where('UserID', '>', 0); // Vanilla can have zeroes here, can't remember why.
@@ -520,8 +513,7 @@ class Flarum extends Target
         $filters = [
             'Body' => 'filterFlarumContent',
         ];
-        $query = $this->porterQB()
-            ->from('Comment')
+        $query = $this->porterQB()->from('Comment')
             // SELECT ORDER IS SENSITIVE DUE TO THE UNION() BELOW.
             ->select([
                 'DiscussionID',
@@ -756,8 +748,7 @@ class Flarum extends Target
         // Get reactions for discussions (OPs).
         if ($this->getDiscussionBodyMode()) {
             // Get highest CommentID.
-            $result = $this->porterQB()
-                ->from('Comment')
+            $result = $this->porterQB()->from('Comment')
                 ->selectRaw('max(CommentID) as LastCommentID')
                 ->first();
             $lastCommentID = $result->LastCommentID ?? 0;


### PR DESCRIPTION
_This feature set is funded through [Open Social Fund](https://nlnet.nl/opensocial), a fund established by [NLnet](https://nlnet.nl/)._

Agorakit is a community platform for civic organizing that was a previous recipient of an NLNet grant. This feature adds Target support for it so that communities can move to it from any source-supported platform.

- [x] a. Data mapping for Agorakit as Target
- [x] b. File transfers for Agorakit as Target

Bonus: Since this is only our second major target, conventions in the OG target (Flarum) are updated as well.