### PR TITLE
fix: wrap column name in array for verifySource schema check

### DIFF
--- a/src/Source.php
+++ b/src/Source.php
@@ -355,7 +355,7 @@ abstract class Source extends Package
                 $missingTables[] = $table;
             } else {
                 foreach ($columns as $col) {
-                    if (!$this->hasInputSchema($table, $col)) { // Column is missing.
+                    if (!$this->hasInputSchema($table, [$col])) { // Column is missing.
                         $missingColumns[] = $table . '.' . $col;
                     }
                 }


### PR DESCRIPTION
## Summary

`Source::verifySource()` passes a single column name (string) to `hasInputSchema()`, which forwards it to `Database::exists()`. However, `exists()` declares `$structure` as `array`, causing a `TypeError` at runtime when any source package defines required columns in its `$sourceTables` property.

This affects source packages like `Smf1` that specify required columns:

```php
public array $sourceTables = array(
    'categories' => array('ID_CAT', 'name', 'catOrder'),
    'members' => array('ID_MEMBER', 'memberName', 'passwd', 'emailAddress', 'dateRegistered'),
    // ...
);
```

### Error

```
TypeError: Porter\Storage\Database::exists(): Argument #2 ($structure) must be of type array, string given,
called in /app/src/Source.php on line 340
```

### Fix

Wrap the single column name in an array before passing it to `hasInputSchema()`, matching the `array` type expected by `Database::exists()`.

### How I found it

Running an SMF 1.1 → Flarum migration with `porter run -s Smf1 -t Flarum`.