### PR TITLE
Add Discord source support (NLNet 1d-1f)

### DIFF
--- a/data/keys.php
+++ b/data/keys.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * Currently unused.
+ */
+
+/**
+ * Record of all keys in the Porter format.
+ */
+return array(
+    'Activity' => array(
+        'ActivityID' => 'int',
+        'ActivityTypeID' => 'int',
+        'NotifyUserID' => 'int',
+        'ActivityUserID' => 'int',
+        'RegardingUserID' => 'int',
+        'RecordID' => 'int',
+        'InsertUserID' => 'int',
+    ),
+    'ActivityComment' => array(
+        'ActivityCommentID' => 'int',
+        'ActivityID' => 'int',
+    ),
+    'ActivityType' => array(
+        'ActivityTypeID' => 'int',
+    ),
+    'Attachment' => array(
+        'AttachmentID' => 'int',
+        'ForeignID' => 'varchar(50)',
+        'ForeignUserID' => 'int',
+        'SourceID' => 'varchar(32)',
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int',
+    ),
+    'Badge' => array(
+        'BadgeID' => 'int',
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int',
+    ),
+    'Category' => array(
+        'CategoryID' => 'int',
+        'ParentCategoryID' => 'int',
+        'PointsCategoryID' => 'int',
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int',
+        'LastCommentID' => 'int',
+        'LastDiscussionID' => 'int',
+    ),
+    'Comment' => array(
+        'CommentID' => 'int',
+        'DiscussionID' => 'int',
+        "parentRecordID" => "int",
+        "parentCommentID" => "int",
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int',
+        'DeleteUserID' => 'int',
+    ),
+    'Conversation' => array(
+        'ConversationID' => 'int',
+        'ForeignID' => 'varchar(40)',
+        'FirstMessageID' => 'int',
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int',
+        'LastMessageID' => 'int',
+        'RegardingID' => 'int'
+    ),
+    'ConversationMessage' => array(
+        'MessageID' => 'int',
+        'ConversationID' => 'int',
+        'InsertUserID' => 'int',
+    ),
+    'Discussion' => array(
+        'DiscussionID' => 'int',
+        'ForeignID' => 'varchar(200)',
+        'CategoryID' => 'int',
+        "statusID" => "int",
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int',
+        'FirstCommentID' => 'int',
+        'LastCommentID' => 'int',
+        'LastCommentUserID' => 'int',
+        'RegardingID' => 'int',
+        'GroupID' => 'int',
+    ),
+    'Event' => array(
+        'EventID' => 'int',
+        'ParentRecordType' => 'varchar(25)',
+        'ParentRecordID' => 'int',
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int',
+        'GroupID' => 'int'
+    ),
+    'Group' => array(
+        'GroupID' => 'int',
+        'CategoryID' => 'int',
+        'LastCommentID' => 'int',
+        'LastDiscussionID' => 'int',
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int',
+    ),
+    'GroupApplicant' => array(
+        'GroupApplicantID' => 'int',
+        'GroupID' => 'int',
+        'UserID' => 'int',
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int'
+    ),
+    'Media' => array( // Attachments
+        'MediaID' => 'int',
+        'InsertUserID' => 'int',
+        'ForeignID' => 'int',
+        'ForeignTable' => 'varchar(100)',
+    ),
+    'Poll' => array(
+        'PollID' => 'int',
+        'DiscussionID' => 'int',
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int'
+    ),
+    'PollOption' => array(
+        'PollOptionID' => 'int',
+        'PollID' => 'int',
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int'
+    ),
+    'PollVote' => array(
+        'UserID' => 'int',
+        'PollOptionID' => 'int'
+    ),
+    'Rank' => array(
+        'RankID' => 'int',
+    ),
+    'ReactionType' => array(
+        'TagID' => 'int',
+    ),
+    'Role' => array(
+        'RoleID' => 'int',
+    ),
+    'Status' => array( // Ideation
+        'StatusID' => 'int',
+        'TagID' => 'int',
+    ),
+    'Tag' => array(
+        'TagID' => 'int',
+        'InsertUserID' => 'int',
+        'CategoryID' => 'int',
+    ),
+    'TagDiscussion' => array(
+        'TagID' => 'int',
+        'DiscussionID' => 'int',
+        'CategoryID' => 'int',
+    ),
+    'User' => array(
+        'UserID' => 'int',
+        'InviteUserID' => 'int',
+        'RankID' => 'int',
+    ),
+    'UserBadge' => array(
+        'UserID' => 'int',
+        'BadgeID' => 'int',
+        'InsertUserID' => 'int'
+    ),
+    'UserCategory' => array(
+        'UserID' => 'int',
+        'CategoryID' => 'int',
+    ),
+    'UserComment' => array(
+        'UserID' => 'int',
+        'CommentID' => 'int',
+    ),
+    'UserConversation' => array(
+        'UserID' => 'int',
+        'ConversationID' => 'int',
+        'LastMessageID' => 'int',
+    ),
+    'UserDiscussion' => array(
+        'UserID' => 'int',
+        'DiscussionID' => 'int',
+    ),
+    'UserEvent' => array(
+        'EventID' => 'int',
+        'UserID' => 'int',
+    ),
+    'UserGroup' => array(
+        'UserGroupID' => 'int',
+        'GroupID' => 'int',
+        'UserID' => 'int',
+        'InsertUserID' => 'int',
+    ),
+    'UserMeta' => array(
+        'UserID' => 'int',
+    ),
+    'UserNote' => array(
+        'UserNoteID' => 'int',
+        'UserID' => 'int',
+        'RecordID' => 'int',
+        'InsertUserID' => 'int',
+        'UpdateUserID' => 'int',
+    ),
+    'UserPoints' => array(
+        'CategoryID' => 'int',
+        'UserID' => 'int',
+    ),
+    'UserRole' => array(
+        'UserID' => 'int',
+        'RoleID' => 'int'
+    ),
+    'UserTag' => array(
+        'RecordID' => 'int',
+        'TagID' => 'int',
+        'UserID' => 'int',
+    ),
+);

--- a/data/structure.php
+++ b/data/structure.php
@@ -495,6 +495,7 @@ return array(
         'PollID' => 'int',
         'Name' => 'text',
         'DiscussionID' => 'int',
+        'CommentID' => 'int', // Added 2026-05 for Discord
         'CountOptions' => 'int',
         'CountVotes' => 'int',
         'Anonymous' => 'int',

--- a/data/structure.php
+++ b/data/structure.php
@@ -277,6 +277,12 @@ return array(
         'DateInserted' => 'datetime',
         'DateUpdated' => 'datetime'
     ),*/
+    'Emoji' => array(
+        'EmojiID' => 'int',
+        'Name' => 'varchar(100)',
+        'InsertUserID' => 'int',
+        'Animated' => 'tinyint',
+    ),
     'Event' => array(
         'EventID' => 'int',
         'Name' => 'varchar(255)',

--- a/src/Origin/Discord.php
+++ b/src/Origin/Discord.php
@@ -572,6 +572,9 @@ class Discord extends Origin
             // Non-guild authors.
             $this->extractAuthors($info['content']);
 
+            // Polls.
+            $this->extractPolls($info['content']);
+
             // Update status.
             if (0 === (int)$info['rows']) {
                 // Change status to 'done' if no more rows found.
@@ -649,6 +652,7 @@ class Discord extends Origin
                 if (!empty($reaction['emoji']['id'])) {
                     $emojiList[$reaction['emoji']['id']] = $reaction['emoji']; // Only collect non-standard emoji.
                 }
+                // todo https://docs.discord.com/developers/resources/message#get-reactions
                 $reactList[] = [
                     'emoji_id' => $reaction['emoji']['id'] ?? 0, // Std unicode emoji ID = null.
                     'emoji_name' => $reaction['emoji']['name'] ?? '',
@@ -674,6 +678,27 @@ class Discord extends Origin
         $emojiData = array_diff_key($emojis, array_combine($this->guildEmojis, $this->guildEmojis));
         $this->extract('discord_emojis', self::DB_EMOJIS, $emojiData); // Store new emoji.
         Log::comment("> non-guild emoji(s) added: " .  implode(',', $missingEmojiIDs));
+    }
+
+    /**
+     * Polls are stored as an object on messages.
+     *
+     * @see https://docs.discord.com/developers/resources/poll
+     */
+    protected function extractPolls(array $content): void
+    {
+        //question (obj)
+        //answers (objs) max 10
+            // answer_id
+            // poll_media
+        //expiry
+        //allow_multiselect
+        //layout_type
+        //results? (obj)
+            //is_finalized
+            //answer_counts (objs) - all answers
+                // id
+                // count
     }
 
     /**

--- a/src/Package.php
+++ b/src/Package.php
@@ -52,7 +52,7 @@ abstract class Package
         // files
         'avatars',
         'attachments',
-        'emoji',
+        'emojis',
     ];
 
     /**

--- a/src/Source/Discord.php
+++ b/src/Source/Discord.php
@@ -171,6 +171,61 @@ class Discord extends Source
         $this->export('Emoji', $query, $map);
     }
 
+    protected function reactions(): void
+    {
+        // todo non-custom emoji reactions => Tags
+        $map = [
+            'EmojiID' => 'TagID',
+        ];
+        $query = $this->sourceQB()->from('discord_emojis')->select('discord_emojis.*')
+            ->selectRaw('"reaction" as Type');
+        $this->export('Tag', $query, $map);
+
+        // All tags are reactions.
+        $query = $this->porterQB()->from('Tag')->select(['Name', 'TagID']);
+        $this->export('ReactionType', $query);
+
+        $map = [
+            'TagID',
+            'DiscussionID',
+            'DateInserted',
+        ];
+        $query = $this->sourceQB()->from('discord_reactions')->select('discord_reactions.*');
+        $this->export('TagDiscussion', $query, $map);
+    }
+
+    protected function polls(): void
+    {
+        $map = [
+            'id' => 'PollID',
+            'name' => 'Name',
+            //'DiscussionID',
+            'message_id' => 'CommentID',
+            //'CountOptions',
+            //'CountVotes',
+            //'DateInserted',
+            //'InsertUserID',
+        ];
+        $query = $this->sourceQB()->from('discord_polls')->select('discord_polls.*');
+        $this->export('Poll', $query, $map);
+
+        $map = [
+            'id' => 'PollOptionID',
+            //'PollID',
+            //'Body',
+            //'CountVotes',
+        ];
+        $query = $this->sourceQB()->from('discord_polloptions')->select('discord_polloptions.*');
+        $this->export('PollOptions', $query, $map);
+
+        $map = [
+            //'UserID',
+            //'PollOptionID',
+        ];
+        $query = $this->sourceQB()->from('discord_pollvotes')->select('discord_pollvotes.*');
+        $this->export('PollVote', $query, $map);
+    }
+
     /**
      * Discord SnowflakeIDs have timestamps embedded within them.
      *

--- a/src/Source/Discord.php
+++ b/src/Source/Discord.php
@@ -24,19 +24,15 @@ class Discord extends Source
             'Discussions' => 1,
             'Comments' => 1,
             'Roles' => 1,
-            // @todo
-            'Avatars' => 0,
-            'Attachments' => 0,
-            'Polls' => 0,
-            'Reactions' => 0,
-            // Not possible.
-            'Passwords' => 0,
-            'AvatarThumbnails' => 0,
-            'PrivateMessages' => 0,
-            'Signatures' => 0,
-            'Bookmarks' => 0,
+            'Avatars' => 1,
+            'Attachments' => 1,
+            'Emoji' => 1,
+            'Reactions' => 0, // No Origin support yet — requires separate calls
+            'Polls' => 0, // No Origin support yet — requires inline unpacking
         ]
     ];
+
+    public const int DISCORD_EPOCH_DIFF = 1288834974657;
 
     public const array CHANNEL_TYPE = [
         'GUILD_TEXT' => 0,
@@ -48,7 +44,7 @@ class Discord extends Source
 
     protected const array FLAGS = [
         'hasDiscussionBody' => false,
-        //'fileTransferSupport' => true,
+        'fileTransferSupport' => true,
         'renumberIndices' => true,  // @todo respect this flag
     ];
 
@@ -57,9 +53,12 @@ class Discord extends Source
         $map = [
             'id' => 'UserID',
             'derived_name' => 'Name', // prefer 1) nick 2) global_name 3) username
+            'derived_avatar' => 'Photo', // prefer guild-specific 'avatar' to 'global_avatar'
+            'joined_at' => 'DateInserted', // Guild-specific date
         ];
         $query = $this->sourceQB()->from('discord_users')->select('discord_users.*')
-            ->selectRaw('COALESCE(nick, COALESCE(global_name, username)) as derived_name');
+            ->selectRaw('COALESCE(nick, COALESCE(global_name, username)) as derived_name')
+            ->selectRaw('COALESCE(avatar, global_avatar) as derived_avatar');
         $this->export('User', $query, $map);
     }
 
@@ -68,6 +67,7 @@ class Discord extends Source
         $map = [
             'id' => 'RoleID',
             'name' => 'Name',
+            //position, managed, mentionable
         ];
         $query = $this->sourceQB()->from('discord_roles')->distinct('id')->select();
         $this->export('Role', $query, $map);
@@ -86,6 +86,10 @@ class Discord extends Source
         $map = [
             'id' => 'CategoryID',
             'name' => 'Name',
+            'parent_id' => 'ParentCategoryID',
+            'position' => 'Sort',
+            'topic' => 'Description',
+            'last_message_id' => 'LastCommentID',
         ];
         $query = $this->sourceQB()->from('discord_channels')->select('discord_channels.*')
             ->whereIn('type', [
@@ -103,12 +107,17 @@ class Discord extends Source
             'name' => 'Name',
             'parent_id' => 'CategoryID',
             'owner_id' => 'InsertUserID',
+            'last_message_id' => 'LastCommentID',
+            'message_count' => 'LastCommentID',
+            'derived_timestamp' => 'DateInserted',
         ];
         $filters = [
             'parent_id' => fn($val, $col, $row) // Text channels use 'id' as 'parent_id' — they are their own category.
-                => (Discord::CHANNEL_TYPE['GUILD_TEXT'] === $row['type']) ? $row['id'] : $row['parent_id']
+                => (Discord::CHANNEL_TYPE['GUILD_TEXT'] === $row['type']) ? $row['id'] : $row['parent_id'],
+            'derived_timestamp' => __NAMESPACE__ . '\Discord::timestampFromSnoflake',
         ];
         $query = $this->sourceQB()->from('discord_channels')->select('discord_channels.*')
+            ->selectRaw('id as derived_timestamp')
             ->whereIn('type', [
                 self::CHANNEL_TYPE['PUBLIC_THREAD'],
                 self::CHANNEL_TYPE['GUILD_ANNOUNCEMENT'],
@@ -124,10 +133,56 @@ class Discord extends Source
             'content' => 'Body',
             'channel_id' => 'DiscussionID',
             'authorid' => 'InsertUserID',
+            'pinned' => 'Announce',
+            //'embeds' => '',
+                // [{"type":"link","url":"http:\/\/www.example.com","description":"Your source for video game news..."}]
         ];
         $query = $this->sourceQB()->from('discord_messages')->select('discord_messages.*')
             ->selectRaw('timestamp(timestamp) as DateInserted')
             ->selectRaw('timestamp(edited_timestamp) as DateUpdated');
         $this->export('Comment', $query, $map);
+    }
+
+    protected function attachments(): void
+    {
+        $map = [
+            'id' => 'MediaID',
+            'message_id' => 'ForeignID',
+            'filename' => 'Name',
+            'width' => 'ImageWidth',
+            'height' => 'ImageHeight',
+            'size' => 'Size',
+            'content_type' => 'Type',
+            'download_path' => 'SourceFullPath',
+        ];
+        $query = $this->sourceQB()->from('discord_attachments')->select('discord_attachments.*');
+        $this->export('Media', $query, $map);
+    }
+
+    protected function emojis(): void
+    {
+        $map = [
+            'id' => 'EmojiID',
+            'name' => 'Name',
+            'animated' => 'Animated',
+            'user.id' => 'InsertUserID',
+        ];
+        $query = $this->sourceQB()->from('discord_emojis')->select('discord_emojis.*');
+        $this->export('Emoji', $query, $map);
+    }
+
+    /**
+     * Discord SnowflakeIDs have timestamps embedded within them.
+     *
+     * @param mixed $value A Discord SnowflakeID
+     * @return int|null Unix timestamp
+     */
+    protected function timestampFromSnoflake(mixed $value): ?int
+    {
+        if (empty($value)) {
+            return null;
+        }
+        $timestamp = substr(decbin((int) $value), 0, -22);
+        return bindec($timestamp) + self::DISCORD_EPOCH_DIFF;
     }
 }

--- a/src/Source/Discord.php
+++ b/src/Source/Discord.php
@@ -45,7 +45,7 @@ class Discord extends Source
     protected const array FLAGS = [
         'hasDiscussionBody' => false,
         'fileTransferSupport' => true,
-        'renumberIndices' => true,  // @todo respect this flag
+        'renumberIndices' => true,
     ];
 
     protected function users(): void
@@ -114,7 +114,7 @@ class Discord extends Source
         $filters = [
             'parent_id' => fn($val, $col, $row) // Text channels use 'id' as 'parent_id' — they are their own category.
                 => (Discord::CHANNEL_TYPE['GUILD_TEXT'] === $row['type']) ? $row['id'] : $row['parent_id'],
-            'derived_timestamp' => __NAMESPACE__ . '\Discord::timestampFromSnoflake',
+            'derived_timestamp' => __NAMESPACE__ . '\Discord::timestampFromSnowflake',
         ];
         $query = $this->sourceQB()->from('discord_channels')->select('discord_channels.*')
             ->selectRaw('id as derived_timestamp')
@@ -177,7 +177,7 @@ class Discord extends Source
      * @param mixed $value A Discord SnowflakeID
      * @return int|null Unix timestamp
      */
-    protected function timestampFromSnoflake(mixed $value): ?int
+    protected function timestampFromSnowflake(mixed $value): ?int
     {
         if (empty($value)) {
             return null;


### PR DESCRIPTION
_This feature set is funded through [Open Social Fund](https://nlnet.nl/opensocial), a fund established by [NLnet](https://nlnet.nl/)._

Automate the mapping of Discord data as a new source, fulfilling NLNet goals 1d, 1e, and 1f:

- [x]  Index renumbering support
   - see: 98c6425bbe2e8a7aa4bb5f4ac430ab1afad28330 (#98 post-acceptance)
   - see: 8599b9df6e031c4574f0998c9159979a55a4436a (#98 post-acceptance) 
- [x]  Data mapping for Discord as Source
   - [x] users
   - [x] roles
   - [x] categories
   - [x] discussions
   - [x] emojis
   - [ ] polls
   - [ ] reactions
- [x] File transfers for Discord as Source