### PR TITLE
Discord: Expand support (NLNet, cont. #3 substitution)

### DIFF
--- a/data/structure.php
+++ b/data/structure.php
@@ -502,7 +502,9 @@ return array(
         'DateInserted' => 'datetime',
         'InsertUserID' => 'int',
         'DateUpdated' => 'datetime',
-        'UpdateUserID' => 'int'
+        'UpdateUserID' => 'int',
+        'AllowMultiple' => 'tinyint',  // Added 2026-07 for Discord
+        'DateClosed' => 'datetime', // Added 2026-07 for Discord
     ),
     'PollOption' => array(
         'PollOptionID' => 'int',
@@ -514,7 +516,8 @@ return array(
         'DateInserted' => 'datetime',
         'InsertUserID' => 'int',
         'DateUpdated' => 'datetime',
-        'UpdateUserID' => 'int'
+        'UpdateUserID' => 'int',
+        'EmojiID' => 'int', // Added 2026-07 for Discord
     ),
     'PollVote' => array(
         'UserID' => 'int',

--- a/data/structure.php
+++ b/data/structure.php
@@ -199,7 +199,7 @@ return array(
         //'UpdateIPAddress' => 'varbinary',
         'Flag' => 'tinyint',
         'Score' => 'float',
-        'Attributes' => 'text',
+        'Attributes' => 'text', // Vanilla serialized Reactions here for point-in-time reference. See: UserTag.
         'QnA' => 'varchar(255)', // 'Accepted', 'Rejected'
     ),
     'Conversation' => array(
@@ -256,7 +256,7 @@ return array(
         'DateLastComment' => 'datetime',
         'LastCommentUserID' => 'int',
         'Score' => 'float',
-        'Attributes' => 'text',
+        'Attributes' => 'text', // Vanilla serialized Reactions here for point-in-time reference. See: UserTag.
         'RegardingID' => 'int',
         'GroupID' => 'int',
         'QnA' => 'varchar(255)', // 'Accepted', 'Answered', 'Rejected', 'Unanswered',
@@ -810,7 +810,7 @@ return array(
         'UserID' => 'int',
         'RoleID' => 'int'
     ),
-    'UserTag' => array(
+    'UserTag' => array( // Reactions
         'RecordType' => 'varchar(200)', //'Discussion', 'Discussion-Total', 'Comment', 'Comment-Total',
         //  'User', 'User-Total', 'Activity', 'Activity-Total', 'ActivityComment', 'ActivityComment-Total'
         'RecordID' => 'int',

--- a/src/Origin.php
+++ b/src/Origin.php
@@ -48,6 +48,7 @@ abstract class Origin extends Package
      * @param string|null $key A non-null value will discard other data & use this key (only) as the data.
      * @param array $query
      * @param array $map
+     * @param array $storeAll A set of [name => value] to insert into ALL resulting records.
      * @return array $info from store()
      * @see Migration::import() for comparison.
      */
@@ -57,7 +58,8 @@ abstract class Origin extends Package
         string $tableName,
         ?string $key = null,
         array $query = [],
-        array $map = []
+        array $map = [],
+        array $storeAll = []
     ): array {
         // Start timer.
         $start = microtime(true);
@@ -79,6 +81,11 @@ abstract class Origin extends Package
             } else {
                 Log::comment("> key '{$key}' not found in response from '{$endpoint}'.");
             }
+        }
+
+        // Add $storeAll to the results.
+        foreach ($content as &$item) {
+            $item = array_merge($item, $storeAll);
         }
 
         // Store the data.

--- a/src/Origin.php
+++ b/src/Origin.php
@@ -12,6 +12,9 @@ abstract class Origin extends Package
     /** @var Storage\Https Where the origin data is from (read-only HTTPS). */
     protected Storage\Https $originStorage;
 
+    /** @var string Folder path to download attachment files into. */
+    protected string $attachmentFolder;
+
     /**
      * @throws \Exception
      */
@@ -146,5 +149,32 @@ abstract class Origin extends Package
         $exists = touchFolder($folder);
         $folders[$name] = ($exists) ? $folder . '/' : '';
         return $folders[$name];
+    }
+
+    /**
+     * Retrieve the file.
+     */
+    protected function getFile(string $url, string $filename): void
+    {
+        if (!$this->attachmentFolder) {
+            return;
+        }
+        $path = $this->attachmentFolder . $filename;
+        if (!file_exists($path)) {
+            $this->originStorage->download($url, $path);
+        } else {
+            Log::comment("Notice: Attachment '{$filename}' already exists.");
+        }
+    }
+
+    /**
+     * Change a filename so that the basename is no more than $length characters.
+     *
+     * Prevents error "Failed to open stream: File name too long".
+     */
+    protected function limitFilenameLength(string $filename, int $length = 100): string
+    {
+        $ext = pathinfo($filename, PATHINFO_EXTENSION);
+        return substr(pathinfo($filename, PATHINFO_FILENAME), 0, $length) . '.' . $ext;
     }
 }

--- a/src/Origin/Discord.php
+++ b/src/Origin/Discord.php
@@ -94,6 +94,13 @@ class Discord extends Origin
         'count' => 'int',
     ];
 
+    protected const array SCHEMA_USERREACTIONS = [
+        'message_id' => 'bigint',
+        'emoji_id' => 'bigint',
+        'user_id' => 'bigint',
+        'emoji_name' => 'varchar(100)',
+    ];
+
     protected const array SCHEMA_ROLES = [
         'id' => 'bigint',
         'name' => 'varchar(100)',
@@ -307,7 +314,7 @@ class Discord extends Origin
     {
         $query = ['limit' => '1000']; // @todo Loop to find remaining users.
         $endpoint = "guilds/" . $this->getGuildId() . "/members";
-        $info = $this->pull($endpoint, self::SCHEMA_USERS, 'discord_users', null, $query, self::MAP_USERS);
+        $info = $this->pull($endpoint, self::SCHEMA_USERS, 'discord_users', null, $query, self::MAP_USERS, []);
         $this->guildUsers = array_column($info['content'], 'id');
         $this->extractUserRoles($info['content']);
     }
@@ -316,7 +323,7 @@ class Discord extends Origin
     protected function roles(): void
     {
         $endpoint = "guilds/" . $this->getGuildId();
-        $this->pull($endpoint, self::SCHEMA_ROLES, 'discord_roles', 'roles');
+        $this->pull($endpoint, self::SCHEMA_ROLES, 'discord_roles', 'roles', [], [], []);
     }
 
     /**
@@ -394,7 +401,7 @@ class Discord extends Origin
     protected function emojis(): void
     {
         $endpoint = "guilds/" . $this->getGuildId() . "/emojis";
-        $info = $this->pull($endpoint, self::SCHEMA_EMOJIS, 'discord_emojis');
+        $info = $this->pull($endpoint, self::SCHEMA_EMOJIS, 'discord_emojis', null, [], [], []);
         $this->guildEmojis = array_column($info['content'], 'id');
     }
 
@@ -459,7 +466,7 @@ class Discord extends Origin
     protected function channels(): void
     {
         $endpoint = "guilds/" . $this->getGuildId() . "/channels";
-        $this->pull($endpoint, self::SCHEMA_CHANNELS, 'discord_channels');
+        $this->pull($endpoint, self::SCHEMA_CHANNELS, 'discord_channels', null, [], [], []);
     }
 
     /**
@@ -471,13 +478,13 @@ class Discord extends Origin
     {
         // Active threads.
         $endpoint = "guilds/" . $this->getGuildId() . "/threads/active";
-        $this->pull($endpoint, self::SCHEMA_CHANNELS, 'discord_channels', 'threads');
+        $this->pull($endpoint, self::SCHEMA_CHANNELS, 'discord_channels', 'threads', [], [], []);
 
         // Archived threads.
         $channelIds = $this->getTextChannels(array_diff(self::TEXT_CHANNEL_TYPES, ['PUBLIC_THREAD'])); // No threads.
         foreach ($channelIds as $channelId) {
             $endpoint = "channels/$channelId/threads/archived/public";
-            $info = $this->pull($endpoint, self::SCHEMA_CHANNELS, 'discord_channels', 'threads');
+            $info = $this->pull($endpoint, self::SCHEMA_CHANNELS, 'discord_channels', 'threads', [], [], []);
             $this->rateLimit($info['headers']);
         }
     }
@@ -558,13 +565,13 @@ class Discord extends Origin
             if (is_numeric($channels[$channelId]) && $channels[$channelId]) {
                 $query['before'] = $channels[$channelId];
             }
-            $info = $this->pull($endpoint, self::SCHEMA_MESSAGES, 'discord_messages', null, $query, $map);
+            $info = $this->pull($endpoint, self::SCHEMA_MESSAGES, 'discord_messages', null, $query, $map, []);
 
             // Attachments.
             $this->extractAttachments($info['content']);
 
             // Reactions & non-guild emoji used in them.
-            $this->extractReactions($info['content']);
+            $this->extractReactions($info['content'], $channelId);
 
             // Non-guild authors.
             $this->extractAuthors($info['content']);
@@ -626,38 +633,72 @@ class Discord extends Origin
     }
 
     /**
-     * Reactions are stored as a LIST of emoji objects on messages.
+     * From a list of messages, extract & store all reactions & their emoji.
      *
-     * Discord doesn't provide individual reaction user_ids or timestamps, only counts.
+     * In discord_reactions, store msg_id + emoji_id + count.
+     * In discord_userreactions, store msg_id + emoji_id + user_id.
+     * In discord_emoji, store all emoji we haven't seen yet.
+     *
+     * Reactions are stored as a LIST of objects on messages, each with emoji + count.
      * @see https://docs.discord.com/developers/resources/message#reaction-object
      * @see https://discord.com/developers/docs/resources/emoji#emoji-object
      * ex: `[{"emoji":{"id":"742118343112130694","name":"gritty"},"count":1},
      *       {"emoji":{"id":"976301342576504912","name":"rockon"},"count":9},
      *       {"emoji":{"id":null,"name": "🔥"},"count":3},
      * }]`
+     *
+     * Individual users' reactions must then be requested per message, per reaction; stored as LIST of users.
+     * @see https://docs.discord.com/developers/resources/message#get-reactions
+     * ex:  `/channels/{channel.id}/messages/{message.id}/reactions/{emoji.id}`
     */
-    protected function extractReactions(array $content): void
+    protected function extractReactions(array $content, int $channelId): void
     {
-        $reactions = array_filter(array_column($content, 'reactions', 'id'), fn ($reactions) => (!empty($reactions)));
-        if (empty($reactions)) {
+        // Filter to messages with reactions and discard other message data.
+        $msgsWithReactions = array_filter(
+            array_column($content, 'reactions', 'id'),
+            fn ($reactions) => (!empty($reactions))
+        );
+        if (empty($msgsWithReactions)) {
             return;
         }
+
+        // Build lists of non-standard emoji to extract & reactions to store.
         $emojiList = [];
         $reactList = [];
-        foreach ($reactions as $msgID => $msgReactions) {
+
+        // Process all messages with reactions.
+        foreach ($msgsWithReactions as $msgId => $msgReactions) {
             foreach ($msgReactions as $reaction) {
-                if (!empty($reaction['emoji']['id'])) {
-                    $emojiList[$reaction['emoji']['id']] = $reaction['emoji']; // Only collect non-standard emoji.
+                $urlEmojiId = $emojiId = $reaction['emoji']['id'];
+
+                // Collect non-standard emoji for fetching.
+                if (!empty($emojiId)) {
+                    // Collect for fetching.
+                    $emojiList[$emojiId] = $reaction['emoji'];
+                    // Special format for GET. "To use custom emoji, you must encode it in the format name:id"
+                    $urlEmojiId = $reaction['emoji']['name'] . ':' . $emojiId;
                 }
-                // todo https://docs.discord.com/developers/resources/message#get-reactions
+
+                // Build reaction list w/ counts for storing.
                 $reactList[] = [
-                    'emoji_id' => $reaction['emoji']['id'] ?? 0, // Std unicode emoji ID = null.
+                    'emoji_id' => $emojiId ?? 0, // Std unicode emoji ID = null.
                     'emoji_name' => $reaction['emoji']['name'] ?? '',
                     'count' => $reaction['count'] ?? 0,
-                    'message_id' => $msgID,
+                    'message_id' => $msgId,
                 ];
+
+                // Pull per-user reactions.
+                $this->pull(
+                    endpoint: "/channels/$channelId/messages/$msgId/reactions/$urlEmojiId",
+                    fields: self::SCHEMA_USERREACTIONS,
+                    tableName: 'discord_userreactions',
+                    map: ['id' => 'user_id'],
+                    storeAll: ['message_id' => $msgId, 'emoji_id' => $emojiId] // Added feature for this use case.
+                );
             }
         }
+
+        // Use collected lists.
         $this->extractEmoji($emojiList);
         $this->extract('discord_reactions', self::SCHEMA_REACTIONS, $reactList);
     }

--- a/src/Origin/Discord.php
+++ b/src/Origin/Discord.php
@@ -129,6 +129,8 @@ class Discord extends Origin
         'poll_id' => 'bigint',
         'answer_id' => 'bigint',
         'count' => 'int',
+        'emoji_id' => 'bigint',
+        'text' => 'text',
     ];
 
     protected const array SCHEMA_POLL_USER_ANSWERS = [

--- a/src/Origin/Discord.php
+++ b/src/Origin/Discord.php
@@ -64,7 +64,7 @@ class Discord extends Origin
         15 => 'GUILD_FORUM',
     ];
 
-    protected const array DB_USERS = [
+    protected const array SCHEMA_USERS = [
         'nick' => 'varchar(100)',
         'avatar' => 'varchar(100)',
         'roles' => 'text',
@@ -87,14 +87,14 @@ class Discord extends Origin
         ],
     ];
 
-    protected const array DB_REACTIONS = [
+    protected const array SCHEMA_REACTIONS = [
         'message_id' => 'bigint',
         'emoji_id' => 'bigint',
         'emoji_name' => 'varchar(100)',
         'count' => 'int',
     ];
 
-    protected const array DB_ROLES = [
+    protected const array SCHEMA_ROLES = [
         'id' => 'bigint',
         'name' => 'varchar(100)',
         'position' => 'int',
@@ -102,14 +102,14 @@ class Discord extends Origin
         'mentionable' => 'tinyint',
     ];
 
-    protected const array DB_EMOJIS = [
+    protected const array SCHEMA_EMOJIS = [
         'id' => 'bigint',
         'name' => 'varchar(100)',
         'user' => 'text', // author
         'animated' => 'tinyint',
     ];
 
-    protected const array DB_CHANNELS = [
+    protected const array SCHEMA_CHANNELS = [
         'id' => 'bigint',
         'type' => 'int', //@todo key?
         'guild_id' => 'bigint',
@@ -135,7 +135,7 @@ class Discord extends Origin
      * @var array Name => column type
      * @see \Porter\Source::renumber() for why an index is important.
      */
-    protected const array DB_MESSAGES = [
+    protected const array SCHEMA_MESSAGES = [
         'id' => 'bigint',
         'channel_id' => 'bigint',
         'content' => 'text',
@@ -172,12 +172,12 @@ class Discord extends Origin
         ],
     ];
 
-    protected const array DB_USERROLES = [
+    protected const array SCHEMA_USERROLES = [
         'user_id' => 'bigint',
         'role_id' => 'bigint',
     ];
 
-    protected const array DB_ATTACHMENTS = [
+    protected const array SCHEMA_ATTACHMENTS = [
         'id' => 'bigint',
         'message_id' => 'bigint',
         'filename' => 'text',
@@ -307,7 +307,7 @@ class Discord extends Origin
     {
         $query = ['limit' => '1000']; // @todo Loop to find remaining users.
         $endpoint = "guilds/" . $this->getGuildId() . "/members";
-        $info = $this->pull($endpoint, self::DB_USERS, 'discord_users', null, $query, self::MAP_USERS);
+        $info = $this->pull($endpoint, self::SCHEMA_USERS, 'discord_users', null, $query, self::MAP_USERS);
         $this->guildUsers = array_column($info['content'], 'id');
         $this->extractUserRoles($info['content']);
     }
@@ -316,7 +316,7 @@ class Discord extends Origin
     protected function roles(): void
     {
         $endpoint = "guilds/" . $this->getGuildId();
-        $this->pull($endpoint, self::DB_ROLES, 'discord_roles', 'roles');
+        $this->pull($endpoint, self::SCHEMA_ROLES, 'discord_roles', 'roles');
     }
 
     /**
@@ -331,7 +331,7 @@ class Discord extends Origin
                 $userRoles[] = ['user_id' => $id, 'role_id' => $roleID];
             }
         }
-        $this->extract('discord_user_roles', self::DB_USERROLES, $userRoles);
+        $this->extract('discord_user_roles', self::SCHEMA_USERROLES, $userRoles);
     }
 
     /**
@@ -373,7 +373,7 @@ class Discord extends Origin
             }
         }
         $errors += $this->originStorage->asyncDownload($files); // Final batch.
-        $this->extract('discord_attachments', self::DB_ATTACHMENTS, $data);
+        $this->extract('discord_attachments', self::SCHEMA_ATTACHMENTS, $data);
     }
 
     /**
@@ -394,7 +394,7 @@ class Discord extends Origin
     protected function emojis(): void
     {
         $endpoint = "guilds/" . $this->getGuildId() . "/emojis";
-        $info = $this->pull($endpoint, self::DB_EMOJIS, 'discord_emojis');
+        $info = $this->pull($endpoint, self::SCHEMA_EMOJIS, 'discord_emojis');
         $this->guildEmojis = array_column($info['content'], 'id');
     }
 
@@ -459,7 +459,7 @@ class Discord extends Origin
     protected function channels(): void
     {
         $endpoint = "guilds/" . $this->getGuildId() . "/channels";
-        $this->pull($endpoint, self::DB_CHANNELS, 'discord_channels');
+        $this->pull($endpoint, self::SCHEMA_CHANNELS, 'discord_channels');
     }
 
     /**
@@ -471,13 +471,13 @@ class Discord extends Origin
     {
         // Active threads.
         $endpoint = "guilds/" . $this->getGuildId() . "/threads/active";
-        $this->pull($endpoint, self::DB_CHANNELS, 'discord_channels', 'threads');
+        $this->pull($endpoint, self::SCHEMA_CHANNELS, 'discord_channels', 'threads');
 
         // Archived threads.
         $channelIds = $this->getTextChannels(array_diff(self::TEXT_CHANNEL_TYPES, ['PUBLIC_THREAD'])); // No threads.
         foreach ($channelIds as $channelId) {
             $endpoint = "channels/$channelId/threads/archived/public";
-            $info = $this->pull($endpoint, self::DB_CHANNELS, 'discord_channels', 'threads');
+            $info = $this->pull($endpoint, self::SCHEMA_CHANNELS, 'discord_channels', 'threads');
             $this->rateLimit($info['headers']);
         }
     }
@@ -558,7 +558,7 @@ class Discord extends Origin
             if (is_numeric($channels[$channelId]) && $channels[$channelId]) {
                 $query['before'] = $channels[$channelId];
             }
-            $info = $this->pull($endpoint, self::DB_MESSAGES, 'discord_messages', null, $query, $map);
+            $info = $this->pull($endpoint, self::SCHEMA_MESSAGES, 'discord_messages', null, $query, $map);
 
             // Attachments.
             $this->extractAttachments($info['content']);
@@ -612,7 +612,7 @@ class Discord extends Origin
 
         // Insert missing users.
         $missingUsers = array_intersect_key($users, $missingUserIDs);
-        $info = $this->extract('discord_users', self::DB_USERS, $missingUsers);
+        $info = $this->extract('discord_users', self::SCHEMA_USERS, $missingUsers);
 
         // Log actions & mark users as "found".
         if (!empty($info['rows'])) { // Missing users were inserted.
@@ -659,7 +659,7 @@ class Discord extends Origin
             }
         }
         $this->extractEmoji($emojiList);
-        $this->extract('discord_reactions', self::DB_REACTIONS, $reactList);
+        $this->extract('discord_reactions', self::SCHEMA_REACTIONS, $reactList);
     }
 
     /**
@@ -673,7 +673,7 @@ class Discord extends Origin
         }
         $this->guildEmojis = array_merge($this->guildEmojis, $missingEmojiIDs); // Update in-memory list.
         $emojiData = array_diff_key($emojis, array_combine($this->guildEmojis, $this->guildEmojis));
-        $this->extract('discord_emojis', self::DB_EMOJIS, $emojiData); // Store new emoji.
+        $this->extract('discord_emojis', self::SCHEMA_EMOJIS, $emojiData); // Store new emoji.
         Log::comment("> non-guild emoji(s) added: " .  implode(',', $missingEmojiIDs));
     }
 

--- a/src/Origin/Discord.php
+++ b/src/Origin/Discord.php
@@ -116,6 +116,27 @@ class Discord extends Origin
         'animated' => 'tinyint',
     ];
 
+    protected const array SCHEMA_POLLS = [
+        'id' => 'bigint',
+        'is_final' => 'tinyint',
+        'text' => 'text',
+        'emoji' => 'bigint',
+        'expiry' => 'datetime',
+        'allow_multiselect' => 'tinyint',
+    ];
+
+    protected const array SCHEMA_POLL_ANSWERS = [
+        'poll_id' => 'bigint',
+        'answer_id' => 'bigint',
+        'count' => 'int',
+    ];
+
+    protected const array SCHEMA_POLL_USER_ANSWERS = [
+        'poll_id' => 'bigint',
+        'answer_id' => 'bigint',
+        'user_id' => 'bigint',
+    ];
+
     protected const array SCHEMA_CHANNELS = [
         'id' => 'bigint',
         'type' => 'int', //@todo key?
@@ -577,7 +598,7 @@ class Discord extends Origin
             $this->extractAuthors($info['content']);
 
             // Polls.
-            $this->extractPolls($info['content']);
+            $this->extractPolls($info['content'], $channelId);
 
             // Update status.
             if (0 === (int)$info['rows']) {
@@ -698,7 +719,7 @@ class Discord extends Origin
             }
         }
 
-        // Use collected lists.
+        // Store collected lists.
         $this->extractEmoji($emojiList);
         $this->extract('discord_reactions', self::SCHEMA_REACTIONS, $reactList);
     }
@@ -719,27 +740,78 @@ class Discord extends Origin
     }
 
     /**
-     * Polls are stored as an object on messages.
+     * From a list of messages, extract & store all polls.
      *
+     * Polls are stored as an object on messages.
      * @see https://docs.discord.com/developers/resources/poll
+     *
+     * Answers are stored as a list of objects.
+     * @see https://docs.discord.com/developers/resources/poll#poll-answer-object-poll-answer-object-structure
+     *
+     * Answer voters are a LIST of user objects per answer.
+     * @see https://docs.discord.com/developers/resources/poll#get-answer-voters
+     * ex: /channels/{channel.id}/polls/{message.id}/answers/{answer_id}
+     *
+     * Ignores edge case where a custom emoji used in a poll option was never used as a reaction.
      */
-    protected function extractPolls(array $content): void
+    protected function extractPolls(array $content, int $channelId): void
     {
-        //question (obj)
-        //answers (objs) max 10
-            // answer_id
-            // poll_media
-        //expiry
-        //allow_multiselect
-        //layout_type
-        //results? (obj)
-            //is_finalized
-            //answer_counts (objs) - all answers
-                // id
-                // count
+        // Filter to messages with polls and discard other message data.
+        $msgsWithPolls = array_filter(
+            array_column($content, 'poll', 'id'),
+            fn ($poll) => (!empty($poll))
+        );
+        if (empty($msgsWithPolls)) {
+            return;
+        }
+
+        // Build lists of all polls & answers.
+        $pollData = [];
+        $answerData = [];
+
+        // Process all messages with reactions.
+        foreach ($msgsWithPolls as $msgId => $poll) {
+            // Build list of all polls in these messages.
+            $pollData = [
+                'message_id' => $msgId, // 1:1 poll:msg associations, so this is the poll_id too.
+                'text' => $poll['text'],
+                'allow_multiselect' => $poll['allow_multiselect'],
+                'expiry' => $poll['expiry'],
+                'emoji_id' => $poll['question']['emoji']['id'],
+                'is_finalized' => (!empty($poll['results'])) ? $poll['results']['is_finalized'] : 0,
+            ];
+
+            // Build list of all answers in these messages w/ counts for storage.
+            $counts = null;
+            if (!empty($poll['results'])) {
+                // Index answer counts by id so they can be referenced in the loop.
+                $counts = array_column($poll['results']['answer_counts'], 'count', 'id');
+            }
+            foreach ($poll['answers'] as $answer) {
+                $answerData = [
+                    'message_id' => $msgId, // 'poll_id' would be the same.
+                    'answer_id' => $answer['answer_id'],
+                    'text' => $answer['poll_media']['text'],
+                    'emoji_id' => $answer['poll_media']['emoji']['id'],
+                    'count' => ($counts) ? $counts[$answer['answer_id']] : 0,
+                ];
+
+                // Pull user-answers. We only need `user_id` from the API.
+                $this->pull(
+                    endpoint: "/channels/$channelId/polls/$msgId/answers/" . $answer['answer_id'],
+                    fields: self::SCHEMA_POLL_USER_ANSWERS,
+                    tableName: 'discord_poll_user_answers',
+                    key: 'users',
+                    map: ['id' => 'user_id'],
+                    storeAll: ['poll_id' => $msgId, 'answer_id' => $answer['answer_id']]
+                );
+            }
+        }
+
+        // Store collected lists.
+        $this->extract('discord_polls', self::SCHEMA_POLLS, $pollData);
+        $this->extract('discord_poll_answers', self::SCHEMA_POLL_ANSWERS, $answerData);
     }
-
-
 
     /**
      * Get URL for a user's Discord avatar.

--- a/src/Origin/Discord.php
+++ b/src/Origin/Discord.php
@@ -94,7 +94,7 @@ class Discord extends Origin
         'count' => 'int',
     ];
 
-    protected const array SCHEMA_USERREACTIONS = [
+    protected const array SCHEMA_USER_REACTIONS = [
         'message_id' => 'bigint',
         'emoji_id' => 'bigint',
         'user_id' => 'bigint',
@@ -197,7 +197,7 @@ class Discord extends Origin
             // Covering index for resuming message pulls [select id where channel_id=x order by timestamp].
             'discord_messages_resuming_index' => [
                 'type' => 'index',
-                'columns' => ['channel_id','timestamp'], // 'id' (pk) is implicitly in index
+                'columns' => ['channel_id', 'timestamp'], // 'id' (pk) is implicitly in index
             ]
         ],
     ];
@@ -659,7 +659,7 @@ class Discord extends Origin
      * From a list of messages, extract & store all reactions & their emoji.
      *
      * In discord_reactions, store msg_id + emoji_id + count.
-     * In discord_userreactions, store msg_id + emoji_id + user_id.
+     * In discord_user_reactions, store msg_id + emoji_id + user_id.
      * In discord_emoji, store all emoji we haven't seen yet.
      *
      * Reactions are stored as a LIST of objects on messages, each with emoji + count.
@@ -673,13 +673,13 @@ class Discord extends Origin
      * Individual users' reactions must then be requested per message, per reaction; stored as LIST of users.
      * @see https://docs.discord.com/developers/resources/message#get-reactions
      * ex:  `/channels/{channel.id}/messages/{message.id}/reactions/{emoji.id}`
-    */
+     */
     protected function extractReactions(array $content, int $channelId): void
     {
         // Filter to messages with reactions and discard other message data.
         $msgsWithReactions = array_filter(
             array_column($content, 'reactions', 'id'),
-            fn ($reactions) => (!empty($reactions))
+            fn($reactions) => (!empty($reactions))
         );
         if (empty($msgsWithReactions)) {
             return;
@@ -713,8 +713,8 @@ class Discord extends Origin
                 // Pull per-user reactions.
                 $this->pull(
                     endpoint: "/channels/$channelId/messages/$msgId/reactions/$urlEmojiId",
-                    fields: self::SCHEMA_USERREACTIONS,
-                    tableName: 'discord_userreactions',
+                    fields: self::SCHEMA_USER_REACTIONS,
+                    tableName: 'discord_user_reactions',
                     map: ['id' => 'user_id'],
                     storeAll: ['message_id' => $msgId, 'emoji_id' => $emojiId] // Added feature for this use case.
                 );
@@ -738,7 +738,7 @@ class Discord extends Origin
         $this->guildEmojis = array_merge($this->guildEmojis, $missingEmojiIDs); // Update in-memory list.
         $emojiData = array_diff_key($emojis, array_combine($this->guildEmojis, $this->guildEmojis));
         $this->extract('discord_emojis', self::SCHEMA_EMOJIS, $emojiData); // Store new emoji.
-        Log::comment("> non-guild emoji(s) added: " .  implode(',', $missingEmojiIDs));
+        Log::comment("> non-guild emoji(s) added: " . implode(',', $missingEmojiIDs));
     }
 
     /**
@@ -761,7 +761,7 @@ class Discord extends Origin
         // Filter to messages with polls and discard other message data.
         $msgsWithPolls = array_filter(
             array_column($content, 'poll', 'id'),
-            fn ($poll) => (!empty($poll))
+            fn($poll) => (!empty($poll))
         );
         if (empty($msgsWithPolls)) {
             return;

--- a/src/Origin/Discord.php
+++ b/src/Origin/Discord.php
@@ -202,9 +202,6 @@ class Discord extends Origin
         ],
     ];
 
-    /** @var string Folder path to download attachment files into. */
-    protected string $attachmentFolder;
-
     /** @var array IDs of guild users used to find non-guild users. */
     protected array $guildUsers;
 
@@ -701,32 +698,7 @@ class Discord extends Origin
                 // count
     }
 
-    /**
-     * Retrieve the file.
-     */
-    protected function getFile(string $url, string $filename): void
-    {
-        if (!$this->attachmentFolder) {
-            return;
-        }
-        $path = $this->attachmentFolder . $filename;
-        if (!file_exists($path)) {
-            $this->originStorage->download($url, $path);
-        } else {
-            Log::comment("Notice: Attachment '{$filename}' already exists.");
-        }
-    }
 
-    /**
-     * Change a filename so that the basename is no more than $length characters.
-     *
-     * Prevents error "Failed to open stream: File name too long".
-     */
-    protected function limitFilenameLength(string $filename, int $length = 100): string
-    {
-        $ext = pathinfo($filename, PATHINFO_EXTENSION);
-        return substr(pathinfo($filename, PATHINFO_FILENAME), 0, $length) . '.' . $ext;
-    }
 
     /**
      * Get URL for a user's Discord avatar.

--- a/src/Source/Discord.php
+++ b/src/Source/Discord.php
@@ -198,29 +198,33 @@ class Discord extends Source
     {
         $map = [
             'id' => 'PollID',
-            'name' => 'Name',
-            //'DiscussionID',
-            'message_id' => 'CommentID',
-            //'CountOptions',
-            //'CountVotes',
-            //'DateInserted',
-            //'InsertUserID',
+            'text' => 'Name',
+            'allow_multiselect' => 'AllowMultiple',
+            'expiry' => 'DateClosed',
         ];
-        $query = $this->sourceQB()->from('discord_polls')->select('discord_polls.*');
+        $query = $this->sourceQB()->from('discord_polls')
+            ->join('discord_messages', 'discord_messages.id', '=', 'discord_polls.id')
+            ->select('discord_polls.*')
+            ->selectRaw('discord_polls.id as CommentID')
+            ->selectRaw('discord_messages.authorid as InsertUserID')
+            ->selectRaw('discord_messages.timestamp as DateInserted')
+            ->selectRaw('discord_messages.edited_timestamp as DateUpdated')
+            ->selectRaw('discord_messages.channel_id as DiscussionID');
         $this->export('Poll', $query, $map);
 
         $map = [
-            'id' => 'PollOptionID',
-            //'PollID',
-            //'Body',
-            //'CountVotes',
+            'poll_id' => 'PollID',
+            'answer_id' => 'PollOptionID',
+            'text' => 'Body',
+            'count' => 'CountVotes',
+            'emoji_id' => 'EmojiID',
         ];
         $query = $this->sourceQB()->from('discord_polloptions')->select('discord_polloptions.*');
         $this->export('PollOptions', $query, $map);
 
         $map = [
-            //'UserID',
-            //'PollOptionID',
+            'user_id' => 'UserID',
+            'answer_id' => 'PollOptionID',
         ];
         $query = $this->sourceQB()->from('discord_pollvotes')->select('discord_pollvotes.*');
         $this->export('PollVote', $query, $map);

--- a/src/Source/Discord.php
+++ b/src/Source/Discord.php
@@ -173,25 +173,41 @@ class Discord extends Source
 
     protected function reactions(): void
     {
-        // todo non-custom emoji reactions => Tags
+        // Tag: Emoji => Reactions => Tags are all the same thing for our purposes.
         $map = [
-            'EmojiID' => 'TagID',
+            'emoji_id' => 'TagID',
+            'name' => 'Name',
         ];
-        $query = $this->sourceQB()->from('discord_emojis')->select('discord_emojis.*')
+        $query = $this->sourceQB()->from('discord_emojis')
+            ->select('discord_emojis.*')
             ->selectRaw('"reaction" as Type');
         $this->export('Tag', $query, $map);
 
-        // All tags are reactions.
-        $query = $this->porterQB()->from('Tag')->select(['Name', 'TagID']);
+        // ReactionType: All Tags we just added are Reactions.
+        $query = $this->porterQB()->from('Tag') // NOTE: PORTERQB!
+            ->select(['Name', 'TagID']);
         $this->export('ReactionType', $query);
 
+        // UserTag: Individual user reactions.
         $map = [
-            'TagID',
-            'DiscussionID',
-            'DateInserted',
+            'emoji_id' => 'TagID',
+            'message_id' => 'RecordID',
+            'user_id' => 'UserID',
         ];
-        $query = $this->sourceQB()->from('discord_reactions')->select('discord_reactions.*');
-        $this->export('TagDiscussion', $query, $map);
+        $query = $this->sourceQB()->from('discord_user_reactions')
+            ->select('discord_user_reactions.*');
+        $this->export('UserTag', $query, $map);
+
+        // UserTag: Reaction counts.
+        $map = [
+            'emoji_id' => 'TagID',
+            'message_id' => 'RecordID',
+            'count' => 'Total',
+        ];
+        $query = $this->sourceQB()->from('discord_reactions')
+            ->select('discord_reactions.*')
+            ->selectRaw('"Comment-Total" as RecordType');
+        $this->export('UserTag', $query, $map);
     }
 
     protected function polls(): void


### PR DESCRIPTION
_This feature set is funded through [Open Social Fund](https://nlnet.nl/opensocial), a fund established by [NLnet](https://nlnet.nl/)._

Expand Discord support from #105 & #101 which already partially substituted for milestone 3 due to scope.

* [x] Framework: Improve `Origin` abstraction & naming
* [x] Framework: `Origin::pull()` can now `$storeAll` (apply a key/value pair to the entire resultset)
* [x] Discord: Retrieve & store per-user reactions
* [x] Discord: Extract polls to their own tables
* [x] Discord: Retrieve & store per-user poll votes
* [x] Discord: Add Source support for Polls
* [x] Discord: Add Source support for Reactions

Bonus: This is providing actual inline docs for using Reactions properly in the Porter format, and it's a weak point in the schema. There's very few packages currently supporting this feature, which needs to change.