### PR TITLE
Add target merging support (NLNet 4a-4d)

### DIFF
--- a/config-sample.php
+++ b/config-sample.php
@@ -27,6 +27,16 @@ return [
     'input_alias' => 'input',
     'output_alias' => 'output',
 
+    // To merge datasets, set these to the current highest ID for each data type (or higher).
+    'offsets' => [
+        'users' => 0,
+        'roles' => 0,
+        'categories' => 0,
+        'discussions' => 0,
+        'comments' => 0,
+        'attachments' => 0,
+    ],
+
     // Data connections.
     'connections' => [
         [

--- a/config-sample.php
+++ b/config-sample.php
@@ -35,6 +35,10 @@ return [
         'discussions' => 0,
         'comments' => 0,
         'attachments' => 0,
+        'polls' => 0,
+        'polloptions' => 0,
+        'tags' => 0, // reactions
+        'badges' => 0,
     ],
 
     // Data connections.

--- a/src/Config.php
+++ b/src/Config.php
@@ -76,11 +76,11 @@ class Config
     }
 
     /**
-     * @todo Allow start IDs per key to be set in config.
+     * Allow start IDs per key to be set in config.
      */
     public function getOffsets(): array
     {
-        return [];
+        return $this->config['offsets'];
     }
 
     /**

--- a/src/Functions/filter.php
+++ b/src/Functions/filter.php
@@ -17,6 +17,22 @@ function filterFlarumContent(?string $value, string $column, array $row): string
 }
 
 /**
+ * Create an offset for the ambiguous RecordID key.
+ */
+function offsetRecord(mixed $value, string $column, array $row): string
+{
+    if (!empty($row['RecordType']) && is_int($value)) {
+        $offsets = \Porter\Config::getInstance()->getOffsets();
+        $offsetName = strtolower($row['RecordType']) . 's';
+        if (!empty($offsets[$offsetName])) { // e.g. ['comments'] = 1000
+            $value += (int)$offsets[strtolower($row['RecordType'])];
+        }
+    }
+
+    return $value;
+}
+
+/**
  * De-duplicate deleted usernames.
  *
  * Check for '[Deleted User]' (and variants) as username and replace.

--- a/src/Target.php
+++ b/src/Target.php
@@ -132,10 +132,12 @@ abstract class Target extends Package
                 // Translate the mapped key to the offset key.
                 $offset = $this->getOffset(self::MERGE_KEYS[$key]);
                 // Create a single-use filter with exactly the correct offset addition.
-                $filters[$key] = function ($value) use ($offset) {
-                    return $value + $offset;
-                };
-                Log::comment(sprintf('Offset %s is set to: %s', $key, $offset));
+                if ($offset) { // Don't set a filter if the offset=0.
+                    $filters[$key] = function ($value) use ($offset) {
+                        return $value + $offset;
+                    };
+                    Log::comment(sprintf('Offset %s is set to: %s', $key, $offset));
+                }
             }
         }
         return $filters;
@@ -282,9 +284,8 @@ abstract class Target extends Package
         // Start timer.
         $start = microtime(true);
 
-        // Auto-detect merge offsets.
-        $addFilters = $this->setOffsets($map); // Keys must be in the $map or auto-offset will fail.
-        $filters = array_merge($filters, $addFilters);
+        // Automate merge offsets. (Keys must be in the $map or auto-offset will fail.)
+        $filters = array_merge($filters, $this->setOffsets($map));
 
         // Prepare the storage medium for the incoming structure.
         $this->outputStorage->prepare($tableName, $struct);

--- a/src/Target.php
+++ b/src/Target.php
@@ -7,7 +7,8 @@ use Staudenmeir\LaravelCte\Query\Builder;
 
 abstract class Target extends Package
 {
-    public const MERGE_KEYS = [
+    /** Map standard Porter schema keys to the config offsets they should use.  */
+    public const array MERGE_KEYS = [
         // Users
         'InsertUserID' => 'users',
         'UpdateUserID' => 'users',
@@ -42,20 +43,6 @@ abstract class Target extends Package
         'PollOptionID' => 'polloptions',
         'TagID' => 'tags',
         'BadgeID' => 'badges',
-        //'GroupID' => 'groups',
-
-        // PMs
-        //'ConversationID' => 'int',
-        //'ForeignID' => 'varchar(40)',
-        //'FirstMessageID' => 'int',
-        //'LastMessageID' => 'int',
-        //'RegardingID' => 'int'
-        //'MessageID' => 'int',
-        //'ConversationID' => 'int',
-
-        // Needs context.
-        //'RecordID' => 'int',
-        //"parentRecordID" => "int",
     ];
 
     /** @var ConnectionManager  */

--- a/src/Target.php
+++ b/src/Target.php
@@ -55,6 +55,20 @@ abstract class Target extends Package
     }
 
     /**
+     * Get the configured offset value.
+     */
+    protected function getOffset(string $name): int
+    {
+        $valid = ['users', 'roles', 'categories', 'discussions', 'comments', 'attachments'];
+        if (!in_array($name, $valid)) {
+            Log::comment('Invalid offset name: ' . $name);
+            return 0;
+        }
+        $offsets = Config::getInstance()->getOffsets();
+        return (!empty($offsets[$name]) && is_numeric($offsets[$name])) ? (int) $offsets[$name] : 0;
+    }
+
+    /**
      * Find duplicate records on the given table + column.
      */
     protected function findDuplicates(string $table, string $column): array

--- a/src/Target.php
+++ b/src/Target.php
@@ -125,6 +125,8 @@ abstract class Target extends Package
                     };
                     Log::comment(sprintf('Offset %s is set to: %s', $key, $offset));
                 }
+            } elseif ('RecordID' === $key) {
+                $filters[$key] = 'offsetRecord';
             }
         }
         return $filters;

--- a/src/Target.php
+++ b/src/Target.php
@@ -7,6 +7,57 @@ use Staudenmeir\LaravelCte\Query\Builder;
 
 abstract class Target extends Package
 {
+    public const MERGE_KEYS = [
+        // Users
+        'InsertUserID' => 'users',
+        'UpdateUserID' => 'users',
+        'DeleteUserID' => 'users',
+        'ForeignUserID' => 'users',
+        'LastCommentUserID' => 'users',
+
+        // Roles
+        'RoleID' => 'roles',
+
+        // Categories
+        'CategoryID' => 'categories',
+        'ParentCategoryID' => 'categories',
+
+        // Discussions
+        'DiscussionID' => 'discussions',
+        'LastDiscussionID' => 'discussions',
+
+        // Comments
+        'CommentID' => 'comments',
+        "parentCommentID" => "comments",
+        'LastCommentID' => 'comments',
+        'FirstCommentID' => 'comments',
+
+        // Attachments
+        'MediaID' => 'attachments',
+        'ForeignID' => 'attachments',
+        'ForeignTable' => 'attachments',
+
+        // Etc.
+        'PollID' => 'polls',
+        'PollOptionID' => 'polloptions',
+        'TagID' => 'tags',
+        'BadgeID' => 'badges',
+        //'GroupID' => 'groups',
+
+        // PMs
+        //'ConversationID' => 'int',
+        //'ForeignID' => 'varchar(40)',
+        //'FirstMessageID' => 'int',
+        //'LastMessageID' => 'int',
+        //'RegardingID' => 'int'
+        //'MessageID' => 'int',
+        //'ConversationID' => 'int',
+
+        // Needs context.
+        //'RecordID' => 'int',
+        //"parentRecordID" => "int",
+    ];
+
     /** @var ConnectionManager  */
     public ConnectionManager $connection;
 
@@ -59,13 +110,35 @@ abstract class Target extends Package
      */
     protected function getOffset(string $name): int
     {
-        $valid = ['users', 'roles', 'categories', 'discussions', 'comments', 'attachments'];
+        $valid = ['users', 'roles', 'categories', 'discussions', 'comments',
+            'attachments','polls', 'polloptions', 'tags', 'badges'];
         if (!in_array($name, $valid)) {
             Log::comment('Invalid offset name: ' . $name);
             return 0;
         }
         $offsets = Config::getInstance()->getOffsets();
         return (!empty($offsets[$name]) && is_numeric($offsets[$name])) ? (int) $offsets[$name] : 0;
+    }
+
+    /**
+     * Creates $filters closures that add the offset values.
+     */
+    protected function setOffsets(array $map): array
+    {
+        $keys = array_keys($map);
+        $filters = [];
+        foreach ($keys as $key) {
+            if (array_key_exists($key, self::MERGE_KEYS)) {
+                // Translate the mapped key to the offset key.
+                $offset = $this->getOffset(self::MERGE_KEYS[$key]);
+                // Create a single-use filter with exactly the correct offset addition.
+                $filters[$key] = function ($value) use ($offset) {
+                    return $value + $offset;
+                };
+                Log::comment(sprintf('Offset %s is set to: %s', $key, $offset));
+            }
+        }
+        return $filters;
     }
 
     /**
@@ -208,6 +281,10 @@ abstract class Target extends Package
     {
         // Start timer.
         $start = microtime(true);
+
+        // Auto-detect merge offsets.
+        $addFilters = $this->setOffsets($map); // Keys must be in the $map or auto-offset will fail.
+        $filters = array_merge($filters, $addFilters);
 
         // Prepare the storage medium for the incoming structure.
         $this->outputStorage->prepare($tableName, $struct);


### PR DESCRIPTION
_This feature set is funded through [Open Social Fund](https://nlnet.nl/opensocial), a fund established by [NLnet](https://nlnet.nl/)._

- [x] 4a. Index renumbering via offsets in config 
- [ ] 4b. User merging on email option
- [ ] 4c. Support for existing Targets & QA
- [ ] 4d. Feature docs (user guide)