### PR TITLE
Add NodeBB target support (NLNet 2a-2e)

### DIFF
--- a/.docker/run/php/Dockerfile
+++ b/.docker/run/php/Dockerfile
@@ -3,7 +3,7 @@ FROM dunglas/frankenphp:php8.4 AS frankenphp
 # Configure PHP
 RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 
-RUN install-php-extensions pdo_mysql zip exif pcntl intl gd opcache bcmath xsl
+RUN install-php-extensions pdo_mysql zip exif pcntl intl gd opcache bcmath xsl mongodb
 
 # Copy Composer binary from latest Docker image.
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Nitro Porter uses the [GNU AGPL 3.0 license](COPYING) to ensure it remains freel
 
 ## What's Supported?
 
-### 📥 Targets ([3](https://nitroporter.org/targets))
+### 📥 Targets ([4](https://nitroporter.org/targets))
 
 ![Flarum](docs/assets/logos/flarum-300x100.png)
+![NodeBB](docs/assets/logos/nodebb-300x100.png)
 ![Vanilla](docs/assets/logos/vanilla-300x100.png)
 ![Waterhole](docs/assets/logos/waterhole-300x100.png)
 

--- a/compose.yml
+++ b/compose.yml
@@ -41,6 +41,43 @@ services:
       timeout: 3s
       retries: 3
 
+  mongo: # Target store for NodeBB migrations.
+    image: mongo:7
+    container_name: porter-mongo
+    environment:
+      MONGO_INITDB_DATABASE: nodebb
+    ports:
+      - "27018:27017"
+    networks:
+      - porter
+    healthcheck: # Verifies Mongo is available to avoid silent failures.
+      test: [ "CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')" ]
+      start_period: 5s
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  nodebb: # NodeBB v4 install for verifying a completed migration. Point it at the migrated `mongo` db.
+    image: ghcr.io/nodebb/nodebb:latest
+    container_name: porter-nodebb
+    ports:
+      - "4567:4567"
+    environment:
+      NODEBB_DB: mongo
+      NODEBB_DB_HOST: porter-mongo
+      NODEBB_DB_PORT: 27017
+      NODEBB_DB_NAME: nodebb
+      NODEBB_URL: http://localhost:4567
+      # Admin for the verification install. Setup runs non-interactively when these are present.
+      NODEBB_ADMIN_USERNAME: admin
+      NODEBB_ADMIN_PASSWORD: Password123!
+      NODEBB_ADMIN_EMAIL: admin@example.com
+    networks:
+      - porter
+    depends_on:
+      mongo:
+        condition: service_healthy
+
   phpmyadmin:
     image: phpmyadmin
     container_name: porter-pma

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "require": {
         "php": ">=8.4",
         "ext-gd": "*",
+        "ext-mongodb": "*",
         "ext-pdo": "*",
         "ext-zlib": "*",
         "ramsey/collection": "^2",
@@ -50,7 +51,8 @@
         "monolog/monolog": "^3",
         "adhocore/cli": "^1",
         "s9e/text-formatter": "2.15.*",
-        "nadar/quill-delta-parser": "^3"
+        "nadar/quill-delta-parser": "^3",
+        "mongodb/mongodb": "^2"
     },
     "require-dev": {
         "phing/phing": "^2",

--- a/config-sample.php
+++ b/config-sample.php
@@ -26,6 +26,10 @@ return [
     'origin_alias' => 'discord',
     'input_alias' => 'input',
     'output_alias' => 'output',
+    // The `PORT_` intermediary is always relational; keep this on a MySQL/MariaDB connection.
+    // For a document target (e.g. NodeBB on `mongodb`), set `output_alias` to the document store
+    // and point `porter_alias` at a MySQL/MariaDB connection. Defaults to `output_alias`.
+    'porter_alias' => 'output',
 
     // Data connections.
     'connections' => [
@@ -70,6 +74,16 @@ return [
                 'guild_id' => '123', // Server ID
                 //'channels' => ['123', '456'], // Optionally limit to certain Channel IDs
             ],
+        ],
+        [
+            // Document store for a NodeBB target. Use as `output_alias` & keep `porter_alias` on MariaDB.
+            'alias' => 'nodebb',
+            'type' => 'mongodb',
+            'host' => 'porter-mongo',
+            'port' => '27017',
+            'database' => 'nodebb',
+            'username' => '',
+            'password' => '',
         ],
     ],
 

--- a/data/targets.php
+++ b/data/targets.php
@@ -3,5 +3,6 @@
 return [
     'Agorakit',
     'Flarum',
+    'NodeBb',
     'Waterhole',
 ];

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -118,6 +118,31 @@ To use it, set the following fields in your `config.php`:
 If `source_root` & `target_root` are set, Nitro Porter will evaluate whether the source & target support file transfer.
 As of 4.0, only Xenforo -> Flarum is supported as a proof of concept.
 
+### Document targets (NodeBB)
+
+NodeBB runs on MongoDB rather than a SQL database, so Nitro Porter writes the migrated data straight into the Mongo database a NodeBB install is already using.
+
+This target needs the `mongodb` PHP extension, which the Docker image installs for you. On a manual
+setup, add it alongside the other required extensions before running `composer install`.
+
+**Install NodeBB first.** Unlike a SQL target, there are no tables to fill: NodeBB keeps its content *and* its configuration, system groups, category permissions and admin account together in one `objects` collection. Nitro Porter adds to that, renumbering every migrated ID to start above whatever the installer already assigned. Migrating into an empty database gives you a forum with no configuration and no way to log in.
+
+The `compose.yml` provides `mongo` (the target store) and `nodebb` (a v4 install for testing). To run a migration:
+
+1. Start NodeBB and complete its setup, so the database has an admin and its default configuration.
+1. In `config.php`, set `output_alias` to the `nodebb` (Mongo) connection.
+1. Keep `porter_alias` on a MariaDB connection. The `PORT_` intermediary is always relational, even when the final target is MongoDB.
+1. Run the migration, for example from Vanilla:
+```
+porter run -s Vanilla -i input -t NodeBb -o nodebb
+```
+1. Restart NodeBB.
+
+!!! warning "After a NodeBB migration"
+    - **Reset permissions.** Nitro Porter never migrates permissions; reassign them in the NodeBB admin panel. Migrated users are added to `registered-users`, so they inherit whatever that group can do.
+    - **Passwords.** NodeBB uses bcrypt. Hashes only carry over if the source used a compatible algorithm; otherwise affected users must reset their password.
+    - **Re-running.** Each run appends. Restore the database from before the last run rather than migrating twice.
+
 ## Troubleshooting
 
 ### Command 'porter' not found

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -61,6 +61,25 @@
         <td><span class="No">✗</span></td>
         <td><span class="No">✗</span></td>
     </tr>
+    <tr><td class="Platform"><span>NodeBB</span></td>
+        <td><span class="Yes">✓</span></td>
+        <td><span class="Yes">✓</span></td>
+        <td><span class="Yes">✓</span></td>
+        <td><span class="Yes">✓</span></td>
+        <td><span class="Yes">✓</span></td>
+        <td><span class="Yes">✓</span></td>
+        <td><span class="No">✗</span></td>
+        <td><span class="Yes">✓</span></td>
+        <td><span class="No">✗</span></td>
+        <td><span class="Yes">✓</span></td>
+        <td><span class="No">✗</span></td>
+        <td><span class="No">✗</span></td>
+        <td><span class="No">✗</span></td>
+        <td><span class="No">✗</span></td>
+        <td><span class="No">✗</span></td>
+        <td><span class="No">✗</span></td>
+        <td><span class="No">✗</span></td>
+    </tr>
     <tr><td class="Platform"><span>Waterhole</span></td>
         <td><span class="Yes">✓</span></td>
         <td><span class="Yes">✓</span></td>

--- a/src/Config.php
+++ b/src/Config.php
@@ -51,7 +51,7 @@ class Config
     public function get(string $key): ?string
     {
         // Only allow prefixed keys to be accessed directly.
-        if (!in_array(substr($key, 0, 6), ['option', 'source', 'target', 'origin', 'output', 'input_'])) {
+        if (!in_array(substr($key, 0, 6), ['option', 'source', 'target', 'origin', 'output', 'input_', 'porter'])) {
             trigger_error('Config access must use allowed prefix.');
         }
         return $this->config[$key] ?? null;

--- a/src/ConnectionManager.php
+++ b/src/ConnectionManager.php
@@ -4,6 +4,8 @@ namespace Porter;
 
 use Illuminate\Database\Capsule\Manager as DatabaseManager;
 use Illuminate\Database\Connection;
+use MongoDB\Client;
+use MongoDB\Database;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -13,7 +15,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class ConnectionManager
 {
     /** @var array Valid values for $type. */
-    public const ALLOWED_TYPES = ['database', 'files', 'api'];
+    public const ALLOWED_TYPES = ['database', 'files', 'api', 'mongodb'];
 
     protected string $type = 'database';
 
@@ -21,8 +23,8 @@ class ConnectionManager
 
     protected array $info = [];
 
-    /** @var Connection|HttpClientInterface Data connection. */
-    protected Connection|HttpClientInterface $connection;
+    /** @var Connection|HttpClientInterface|Database Data connection. */
+    protected Connection|HttpClientInterface|Database $connection;
 
     public DatabaseManager $dbm;
 
@@ -51,6 +53,8 @@ class ConnectionManager
             $this->setupDatabase($info, $prefix);
         } elseif ($info['type'] === 'api') {
             $this->setupHttp($info);
+        } elseif ($info['type'] === 'mongodb') {
+            $this->setupMongo($info);
         }
     }
 
@@ -88,11 +92,19 @@ class ConnectionManager
     }
 
     /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
      * Get the current DBM connection.
      *
-     * @return Connection|HttpClientInterface
+     * @return Connection|HttpClientInterface|Database
      */
-    public function connection(): Connection|HttpClientInterface
+    public function connection(): Connection|HttpClientInterface|Database
     {
         return $this->connection;
     }
@@ -180,5 +192,21 @@ class ConnectionManager
         // Allowlist http-clients config options.
         $info = array_intersect_key($info, array_flip(['base_uri', 'extra']));
         $this->connection = HttpClient::create()->withOptions($info);
+    }
+
+    /**
+     * Setup MongoDB client and select the target database.
+     *
+     * @param array $info
+     */
+    protected function setupMongo(array $info): void
+    {
+        // Build a connection string, including credentials only when provided.
+        $auth = '';
+        if (!empty($info['username'])) {
+            $auth = rawurlencode($info['username']) . ':' . rawurlencode($info['password'] ?? '') . '@';
+        }
+        $uri = 'mongodb://' . $auth . $info['host'] . ':' . ($info['port'] ?? '27017');
+        $this->connection = new Client($uri)->getDatabase($info['database']);
     }
 }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -107,6 +107,7 @@ class Controller
         $targetName = $request->getTarget();
         $inputName = $request->getInput();
         $outputName = $request->getOutput();
+        $porterName = $request->getPorter();
         $sourcePrefix = $request->getInputTablePrefix();
         $targetPrefix = $request->getOutputTablePrefix();
         $dataTypes = $request->getDatatypes();
@@ -115,19 +116,19 @@ class Controller
         Log::comment("NITRO PORTER RUNNING...");
         Log::comment("Porting " . $sourceName . " to " . $targetName);
         Log::comment("Input: " . $inputName . ' (' . ($sourcePrefix ?? 'no prefix') . ')');
-        Log::comment("Porter: " . $outputName . ' (PORT_)');
+        Log::comment("Porter: " . $porterName . ' (PORT_)');
         Log::comment("Output: " . $outputName . ' (' . ($targetPrefix ?? 'no prefix') . ')');
         Log::comment("\n" . sprintf('[ STARTED at %s ]', date('H:i:s e')) . "\n");
 
         // Factory for migration artifacts.
         $inputStorage = Factory::storage($inputName, $sourcePrefix);
-        $porterStorage = Factory::storage($outputName, 'PORT_');
+        $porterStorage = Factory::storage($porterName, 'PORT_');
         $outputStorage = Factory::storage($outputName, $targetPrefix);
         $postscriptStorage = Factory::storage($outputName, $targetPrefix); // Postscript names must match target names.
         $source = Factory::source($sourceName, $inputStorage, $porterStorage);
         $target = Factory::target($targetName, $porterStorage, $outputStorage);
         $postscript = Factory::postscript($targetName, $outputStorage, $postscriptStorage);
-        $fileTransfer = Factory::fileTransfer($source, $target, $outputName);
+        $fileTransfer = Factory::fileTransfer($source, $target, $porterName);
 
         // Set constraints.
         $source->limitTables($dataTypes);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -9,9 +9,10 @@ class Factory
     /**
      * Setup a new FileTransfer service.
      */
-    public static function fileTransfer(Source $source, Target $target, string $outputName): FileTransfer
+    public static function fileTransfer(Source $source, Target $target, string $porterName): FileTransfer
     {
-        $porterStorage = new Storage\Database(new ConnectionManager($outputName, 'PORT_'));
+        // The `PORT_` intermediary is always relational, so read it via the porter (SQL) connection.
+        $porterStorage = new Storage\Database(new ConnectionManager($porterName, 'PORT_'));
         return new FileTransfer($source, $target, $porterStorage);
     }
 
@@ -73,6 +74,10 @@ class Factory
         if ($name === 'file') { // @todo storageFactory
             return new Storage\File();
         }
-        return new Storage\Database(new ConnectionManager($name, $prefix));
+        $connection = new ConnectionManager($name, $prefix);
+        if ($connection->getType() === 'mongodb') {
+            return new Storage\Mongo($connection);
+        }
+        return new Storage\Database($connection);
     }
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -59,6 +59,37 @@ class Formatter
     }
 
     /**
+     * Render content to HTML, for targets that store rendered markup rather than TextFormatter XML.
+     *
+     * @param ?string $format
+     * @param ?string $text
+     * @return string
+     */
+    public function toHtml(?string $format, ?string $text): string
+    {
+        if ($text === null) {
+            return '';
+        }
+        switch (strtolower((string)$format)) {
+            case 'html':
+            case 'wysiwyg':
+            case 'raw': // Unfiltered, so these could break.
+                return (string)self::fixIllegalTags(self::closeTags($text));
+            case 'markdown':
+                return Markdown::render(Markdown::parse($text));
+            case 'bbcode':
+                return BBCode::render(BBCode::parse($text));
+            case 'rich': // Quill
+                return self::dequill($text);
+            case 'text':
+            case 'textex':
+            default:
+                // Escape first: the value is literal text, so any markup in it is not markup.
+                return nl2br(htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+        }
+    }
+
+    /**
      * Put content in TextFormatter-compatible format.
      *
      * @param ?string $format

--- a/src/Functions/filter.php
+++ b/src/Functions/filter.php
@@ -539,10 +539,10 @@ function bb_Decodeit(array $matches): string
  * Removes everything from `$path` after final '/', then re-appends the filename
  * with 'p' now prepended (if it didn't already start with 'p' to prevent compounding it).
  *
- * @param string $path
- * @return string
+ * @param ?string $path
+ * @return ?string
  */
-function vanillaPhoto(?string $path): string
+function vanillaPhoto(?string $path): ?string
 {
     // Skip processing for blank entries.
     if (empty($path)) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -25,6 +25,7 @@ class Request
     private ?string $targetName;
     private ?string $inputConnection;
     private ?string $outputConnection;
+    private ?string $porterConnection;
     private string $inputTablePrefix = '';
     private string $outputTablePrefix = '';
     private ?string $cdnPrefix;
@@ -61,6 +62,8 @@ class Request
 
         $this->inputConnection = $inputConnection ?? Config::getInstance()->get('input_alias');
         $this->outputConnection = $outputConnection ?? Config::getInstance()->get('output_alias');
+        // The `PORT_` intermediary is always relational; falls back to the output connection.
+        $this->porterConnection = Config::getInstance()->get('porter_alias') ?: $this->outputConnection;
 
         // Table prefixes: CLI > Config > Package defaults
         if (!empty($this->sourceName)) {
@@ -107,6 +110,11 @@ class Request
     public function getOutput(): ?string
     {
         return $this->outputConnection;
+    }
+
+    public function getPorter(): ?string
+    {
+        return $this->porterConnection;
     }
 
     public function getInputTablePrefix(): ?string

--- a/src/Storage/Mongo.php
+++ b/src/Storage/Mongo.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Porter\Storage;
+
+use MongoDB\Collection;
+use MongoDB\Database;
+use Porter\ConnectionManager;
+use Porter\Storage;
+
+/**
+ * Document storage for targets that run on MongoDB.
+ *
+ * Buffers inserts & flushes them with `insertMany()`, and exposes the read/update primitives a
+ * document target needs. Collections & document shapes are the target's business, not this class'.
+ * No schema to prepare, so the relational `Storage` contract methods are no-ops.
+ */
+class Mongo extends Storage
+{
+    /** @var int How many documents to write per `insertMany()`. */
+    public const int INSERT_BATCH = 1000;
+
+    /** @var ConnectionManager */
+    protected ConnectionManager $connectionManager;
+
+    /** @var array Documents pending insert, keyed by collection name. */
+    protected array $buffer = [];
+
+    /** @param ConnectionManager $c */
+    public function __construct(ConnectionManager $c)
+    {
+        $this->connectionManager = $c;
+    }
+
+    /**
+     * Reference to the underlying library.
+     *
+     * Note this is a Mongo `Database`, not an Illuminate `Connection`, so the `dbOutput()` and
+     * `dbPorter()` accessors on Target/Postscript cannot be pointed at this storage. Packages
+     * using it must reach for the primitives below instead.
+     *
+     * @return Database
+     */
+    public function getHandle(): Database
+    {
+        return $this->connectionManager->connection();
+    }
+
+    /**
+     * Buffer a document for insert, flushing the collection once a batch has accumulated.
+     *
+     * @param string $collection
+     * @param array $document
+     */
+    public function insert(string $collection, array $document): void
+    {
+        $this->buffer[$collection][] = $document;
+        if (count($this->buffer[$collection]) >= self::INSERT_BATCH) {
+            $this->flushCollection($collection);
+        }
+    }
+
+    /**
+     * Read one document, or null if none matches.
+     *
+     * Flushes pending inserts first so a document written this run is visible.
+     *
+     * @param string $collection
+     * @param array $filter
+     * @return array|null
+     */
+    public function findOne(string $collection, array $filter): ?array
+    {
+        $this->flush();
+        $document = $this->collection($collection)
+            ->findOne($filter, ['typeMap' => ['root' => 'array']]);
+
+        return ($document === null) ? null : (array)$document;
+    }
+
+    /**
+     * Apply one update, optionally creating the document if none matches.
+     *
+     * Flushes pending inserts first so a document written this run is there to update.
+     *
+     * @param string $collection
+     * @param array $filter
+     * @param array $update A Mongo update document (e.g. `['$set' => [...]]`).
+     * @param bool $upsert
+     */
+    public function updateOne(string $collection, array $filter, array $update, bool $upsert = false): void
+    {
+        $this->flush();
+        $this->collection($collection)->updateOne($filter, $update, ['upsert' => $upsert]);
+    }
+
+    /**
+     * Apply many updates in batched, unordered passes.
+     *
+     * Flushes pending inserts first, then batches to avoid a round-trip per operation.
+     *
+     * @param string $collection
+     * @param array $operations List of `['updateOne' => [$filter, $update, $options]]`.
+     */
+    public function bulkWrite(string $collection, array $operations): void
+    {
+        $this->flush();
+        $batch = [];
+        foreach ($operations as $operation) {
+            $batch[] = $operation;
+            if (count($batch) >= self::INSERT_BATCH) {
+                $this->collection($collection)->bulkWrite($batch, ['ordered' => false]);
+                $batch = [];
+            }
+        }
+        if (!empty($batch)) {
+            $this->collection($collection)->bulkWrite($batch, ['ordered' => false]);
+        }
+    }
+
+    /**
+     * Drop a collection so a fresh migration starts from a clean slate.
+     *
+     * @param string $collection
+     */
+    public function drop(string $collection): void
+    {
+        $this->collection($collection)->drop();
+    }
+
+    /**
+     * Create an index on a collection.
+     *
+     * @param string $collection
+     * @param array $key Field => direction (e.g. `['name' => 1]`).
+     * @param array $options
+     */
+    public function createIndex(string $collection, array $key, array $options = []): void
+    {
+        $this->collection($collection)->createIndex($key, $options);
+    }
+
+    /**
+     * Write any buffered documents to their collections.
+     */
+    public function flush(): void
+    {
+        foreach (array_keys($this->buffer) as $collection) {
+            $this->flushCollection($collection);
+        }
+    }
+
+    /**
+     * Insert and clear the buffer for a single collection.
+     *
+     * @param string $collection
+     */
+    protected function flushCollection(string $collection): void
+    {
+        if (empty($this->buffer[$collection])) {
+            return;
+        }
+        $this->collection($collection)->insertMany($this->buffer[$collection]);
+        $this->buffer[$collection] = [];
+    }
+
+    /**
+     * @param string $name
+     * @return Collection
+     */
+    protected function collection(string $name): Collection
+    {
+        return $this->getHandle()->getCollection($name);
+    }
+
+    /**
+     * No schema to prepare; collections are created on first write.
+     *
+     * @param string $resourceName
+     * @param array $structure The final, combined structure to be written.
+     */
+    public function prepare(string $resourceName, array $structure): void
+    {
+        //
+    }
+
+    public function begin(): void
+    {
+        //
+    }
+
+    public function end(): void
+    {
+        $this->flush();
+    }
+
+    /**
+     * @param string $resourceName
+     * @param array $structure
+     * @return bool
+     */
+    public function exists(string $resourceName = '', array $structure = []): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function stream(array $row, array $structure, array $info = [], bool $final = false): array
+    {
+        return [];
+    }
+}

--- a/src/Target/NodeBb.php
+++ b/src/Target/NodeBb.php
@@ -1,0 +1,1248 @@
+<?php
+
+/**
+ * NodeBB v4 target.
+ *
+ * NodeBB runs on MongoDB, so this target writes documents via `Storage\Mongo` rather than the
+ * row-per-table `import()` path. Each record fans out to a `_key` hash plus the sorted sets &
+ * counters NodeBB reads from. Derived data (counts, teasers, etc.) is finalized in the Postscript.
+ *
+ * @see https://docs.nodebb.org/
+ */
+
+namespace Porter\Target;
+
+use Porter\Formatter;
+use Porter\Log;
+use Porter\Storage\Mongo;
+use Porter\Target;
+
+class NodeBb extends Target
+{
+    public const array SUPPORTED = [
+        'name' => 'NodeBB 4.x',
+        'defaultTablePrefix' => '',
+        'avatarPath' => 'public/uploads/profile',
+        'attachmentPath' => 'public/uploads/files',
+        'features' => [
+            'Users' => 1,
+            'Passwords' => 1,
+            'Categories' => 1,
+            'Discussions' => 1,
+            'Comments' => 1,
+            'Roles' => 1,
+            'Avatars' => 1,
+            'Attachments' => 1,
+            'Polls' => 0,
+            'PrivateMessages' => 0,
+            'Signatures' => 0,
+            'Bookmarks' => 0,
+            'Badges' => 0,
+            'Tags' => 0,
+            'Reactions' => 0,
+        ]
+    ];
+
+    protected const array FLAGS = [
+        'hasDiscussionBody' => false, // NodeBB's first post (mainPid) carries the topic body.
+        'fileTransferSupport' => true,
+    ];
+
+    /** @var string Web path NodeBB serves the `public/uploads` folder from. */
+    protected const string UPLOADS_WEB_PATH = '/assets/uploads';
+
+    /** @var string Avatar folder, relative to the uploads root. */
+    protected const string AVATAR_PATH = '/profile';
+
+    /** @var string Attachment folder, relative to the uploads root. NodeBB keys uploads on this path. */
+    protected const string ATTACHMENT_PATH = '/files';
+
+    /** @var string The collection NodeBB keeps all hashes, sets and sorted sets in. */
+    public const string OBJECTS = 'objects';
+
+    /** @var int Rows read per query in the large loops. @see self::comments() */
+    protected const int CHUNK_SIZE = 25000;
+
+    /** @var string Group every NodeBB user belongs to; category privileges are granted to it. */
+    protected const string GROUP_REGISTERED = 'registered-users';
+
+    /** @var array Privileges NodeBB grants members on a new category. @see NodeBB `categories/create.js` */
+    protected const array PRIVILEGES_MEMBER = [
+        'groups:find', 'groups:read', 'groups:topics:read', 'groups:topics:create',
+        'groups:topics:reply', 'groups:topics:crosspost', 'groups:topics:tag',
+        'groups:posts:edit', 'groups:posts:history', 'groups:posts:delete',
+        'groups:posts:upvote', 'groups:posts:downvote', 'groups:topics:delete',
+    ];
+
+    /** @var array Privileges NodeBB adds for moderators on top of the member set. */
+    protected const array PRIVILEGES_MOD = [
+        'groups:topics:schedule', 'groups:posts:view_deleted', 'groups:purge',
+    ];
+
+    /** @var array Privileges NodeBB grants unauthenticated visitors. */
+    protected const array PRIVILEGES_GUEST = ['groups:find', 'groups:read', 'groups:topics:read'];
+
+    /** @var array Which groups receive which privilege set on a migrated category. */
+    protected const array PRIVILEGE_GRANTS = [
+        'member' => ['registered-users', 'fediverse'],
+        'mod' => ['administrators', 'Global Moderators'],
+        'guest' => ['guests', 'spiders'],
+    ];
+
+    /** @var array NodeBB's own groups, which a source role must never overwrite. @see NodeBB `groups/index.js` */
+    protected const array SYSTEM_GROUPS = [
+        'registered-users',
+        'verified-users',
+        'unverified-users',
+        'banned-users',
+        'administrators',
+        'Global Moderators',
+    ];
+
+    /** @var int|null Offset added to comment IDs so reply pids never collide with first-post pids. */
+    protected ?int $pidOffset = null;
+
+    /** @var array|null DiscussionID => pid of its first post. @see self::mainPids() */
+    protected ?array $mainPids = null;
+
+    /** @var array|null pid => list of its attachments. @see self::attachmentsByPid() */
+    protected ?array $attachmentsByPid = null;
+
+    /** @var array|null ID space already used by the target install. @see self::setup() */
+    protected ?array $offsets = null;
+
+    /** @var array Migrated members per group name, for the memberCount NodeBB reads. */
+    protected array $memberCounts = [];
+
+    /**
+     * Read the ID space the target NodeBB has already used, so migrated records append past it.
+     *
+     * The `objects` collection holds NodeBB's config, system groups, `cid:*:privileges:*` records
+     * and admin account alongside its content. Dropping it destroys the install, so records append to it
+     * instead. Every migrated ID therefore starts above what the installer already assigned.
+     */
+    protected function setup(): void
+    {
+        $this->indexPorterTables();
+
+        $global = $this->getObject('global');
+        if ($global === null) {
+            Log::comment('WARNING! No NodeBB install found at the output connection. Install NodeBB '
+                . '& complete its setup BEFORE migrating, or the result will have no config or admin.');
+        }
+        // These hold the LAST id NodeBB assigned, not the next free one: it assigns from the
+        // return of `incrObjectField`, so the counter and the highest live id are equal.
+        $this->offsets = [
+            'uid' => max(0, (int)($global['nextUid'] ?? 0)),
+            'cid' => max(0, (int)($global['nextCid'] ?? 0)),
+            'tid' => max(0, (int)($global['nextTid'] ?? 0)),
+            'pid' => max(0, (int)($global['nextPid'] ?? 0)),
+        ];
+    }
+
+    /**
+     * Index the `PORT_` columns read by the chunked loops.
+     *
+     * The intermediary has no indexes; other targets stream it once so don't need them. Chunked
+     * reads without an index are a full scan + filesort each time. @see self::comments()
+     */
+    protected function indexPorterTables(): void
+    {
+        $db = $this->dbPorter();
+        $schema = $db->getDatabaseName();
+        foreach (['Comment' => 'CommentID', 'Discussion' => 'DiscussionID'] as $table => $column) {
+            $name = 'porter_' . strtolower($column);
+            $exists = $db->selectOne(
+                'select 1 as found from information_schema.statistics
+                    where table_schema = ? and table_name = ? and index_name = ?',
+                [$schema, "PORT_$table", $name]
+            );
+            if ($exists) {
+                continue;
+            }
+            Log::comment("Indexing PORT_$table.$column for chunked reads...");
+            $db->statement("alter table `PORT_$table` add index `$name` (`$column`)");
+        }
+    }
+
+    /**
+     * Start of the ID space this migration may use for a given record type.
+     *
+     * @param string $type One of 'uid', 'cid', 'tid', 'pid'.
+     * @return int
+     */
+    protected function offset(string $type): int
+    {
+        return $this->offsets[$type] ?? 0;
+    }
+
+    /**
+     * Translate a source key into the target's ID space.
+     *
+     * User 0 is guest in both Vanilla and NodeBB, so authorless content stays uid 0 rather than
+     * being offset onto a real account — offsetting it lands on the install's admin (uid 0 + the
+     * offset), silently attributing every guest post to them.
+     */
+    protected function uid(int $userID): int
+    {
+        return ($userID > 0) ? $userID + $this->offset('uid') : 0;
+    }
+
+    protected function cid(int $categoryID): int
+    {
+        return $categoryID + $this->offset('cid');
+    }
+
+    protected function tid(int $discussionID): int
+    {
+        return $discussionID + $this->offset('tid');
+    }
+
+    protected function pid(int $commentID): int
+    {
+        return $commentID + $this->pidOffset();
+    }
+
+    /**
+     * The pid of a discussion's first post.
+     *
+     * With the body mode on the OP is synthesized from `Discussion.Body`, taking its own pid from
+     * the same space as the comments. With it off the OP is an existing comment.
+     *
+     * @param int $discussionID
+     * @return int
+     */
+    protected function opPid(int $discussionID): int
+    {
+        if (!$this->getDiscussionBodyMode()) {
+            $mainPid = $this->mainPids()[$discussionID] ?? 0;
+            return $mainPid ? $this->pid($mainPid) : 0;
+        }
+        return $this->offset('pid') + $discussionID;
+    }
+
+    /**
+     * Enforce data constraints required by NodeBB.
+     */
+    public function validate(): void
+    {
+        $this->uniqueUserNames();
+        $this->uniqueUserEmails();
+        $this->topicsHaveFirstPost();
+    }
+
+    /**
+     * Every NodeBB topic needs a `mainPid`. Report any that can't be pointed at a post.
+     *
+     * Only possible with 'Use Discussion Body' off, where the OP has to be found among the comments.
+     */
+    protected function topicsHaveFirstPost(): void
+    {
+        if ($this->getDiscussionBodyMode()) {
+            return; // The body is on the discussion record, so every topic has one.
+        }
+        // Joined rather than `whereNotIn(...)`: that binds a placeholder per discussion and MySQL
+        // caps a statement at 65535 of them, which a real forum passes easily.
+        $orphans = $this->porterQB()->from('Discussion')
+            ->leftJoin('Comment', 'Comment.DiscussionID', '=', 'Discussion.DiscussionID')
+            ->whereNull('Comment.CommentID')
+            ->count();
+        if ($orphans) {
+            Log::comment("DATA LOSS! Discussions with no posts, so no NodeBB mainPid: $orphans");
+        }
+    }
+
+    /**
+     * Write users as `user:{uid}` hashes, plus the lookup and listing sorted sets.
+     */
+    protected function users(): void
+    {
+        $rows = $this->porterQB()->from('User')
+            ->select([
+                'UserID', 'Name', 'Email', 'Password', 'Banned',
+                'DateInserted', 'DateLastActive', 'TargetAvatarFullPath',
+            ])
+            ->cursor();
+        // NodeBB enforces a unique {_key,value} index, so each lookup value may appear once (first uid wins).
+        $seenName = $seenSlug = $seenEmail = [];
+        $now = $this->now();
+        foreach ($rows as $user) {
+            $uid = $this->uid((int)$user->UserID);
+            // NodeBB requires unique usernames, and every deleted user shares one. Renaming them
+            // is what uniqueUserNames() assumes has happened when it allowlists those names.
+            $name = (string)fixDuplicateDeletedNames((string)$user->Name, 'Name', (array)$user);
+            $slug = $this->slugify($name, (string)$uid);
+            $email = strtolower((string)$user->Email);
+            $joined = $this->toMillis($user->DateInserted);
+            // `filemap()` runs first, so read the destination it set rather than rebuilding it.
+            $picture = empty($user->TargetAvatarFullPath)
+                ? ''
+                : self::UPLOADS_WEB_PATH . self::AVATAR_PATH . '/' . basename((string)$user->TargetAvatarFullPath);
+
+            $this->setObject("user:$uid", [
+                'uid' => $uid,
+                'username' => $name,
+                'userslug' => $slug,
+                'email' => (string)$user->Email,
+                'joindate' => $joined,
+                'lastonline' => $this->toMillis($user->DateLastActive),
+                'postcount' => 0,
+                'topiccount' => 0,
+                'reputation' => 0,
+                'banned' => (int)$user->Banned,
+                'password' => (string)$user->Password, // @see README on password hash compatibility.
+                'picture' => $picture,
+                'uploadedpicture' => $picture,
+            ]);
+
+            // Username and email lookups to uid (deduped: NodeBB requires each value be unique).
+            if ($name !== '' && !isset($seenName[$name])) {
+                $this->sortedSetAdd('username:uid', $name, $uid);
+                $this->sortedSetAdd('username:sorted', strtolower($name) . ':' . $uid, 0); // Search.
+                $seenName[$name] = true;
+            }
+            if ($slug !== '' && !isset($seenSlug[$slug])) {
+                $this->sortedSetAdd('userslug:uid', $slug, $uid);
+                $seenSlug[$slug] = true;
+            }
+            if ($email !== '' && !isset($seenEmail[$email])) {
+                $this->sortedSetAdd('email:uid', $email, $uid);
+                $seenEmail[$email] = true;
+            }
+
+            // User listings.
+            $this->sortedSetAdd('users:joindate', $uid, $joined);
+            $this->sortedSetAdd('users:postcount', $uid, 0);
+            $this->sortedSetAdd('users:reputation', $uid, 0);
+
+            // Every NodeBB user is in `registered-users`; category privileges are granted to it,
+            // so a user outside it cannot read or post anywhere. @see NodeBB `user/create.js`
+            $this->sortedSetAdd('group:' . self::GROUP_REGISTERED . ':members', $uid, $now);
+            $this->memberCounts[self::GROUP_REGISTERED] =
+                ($this->memberCounts[self::GROUP_REGISTERED] ?? 0) + 1;
+        }
+    }
+
+    /**
+     * Write roles as NodeBB groups, and user-role assignments as group membership.
+     */
+    protected function roles(): void
+    {
+        // Verify support.
+        if (!$this->hasPortSchema('UserRole')) {
+            Log::comment('Skipping import: Roles (Source lacks support)');
+            return;
+        }
+
+        // Delete orphaned user role associations (deleted users).
+        $this->pruneOrphanedRecords('UserRole', 'UserID', 'User', 'UserID');
+
+        $now = $this->now();
+
+        $roles = $this->porterQB()->from('Role')->select(['RoleID', 'Name', 'Description'])->cursor();
+        // Groups are keyed by name, and NodeBB indexes `{_key,value}` unique: a duplicate here makes
+        // its index build fail on boot, so the whole forum stops working. Names are also a shared
+        // namespace with NodeBB's own groups, which must not be redefined.
+        $seenGroup = array_fill_keys(array_map('strtolower', self::SYSTEM_GROUPS), true);
+        $groupSlugs = [];
+        foreach ($roles as $role) {
+            $name = (string)$role->Name;
+            if ($name === '' || isset($seenGroup[strtolower($name)])) {
+                Log::comment("DATA LOSS! Role skipped for duplicate or reserved group name: $name");
+                continue;
+            }
+            $seenGroup[strtolower($name)] = true;
+
+            $this->setObject("group:$name", [
+                'name' => $name,
+                'slug' => $this->slugify($name, 'group'),
+                'description' => (string)$role->Description,
+                'createtime' => $now,
+                'memberCount' => 0,
+                'hidden' => 0,
+                'system' => 0,
+                'private' => 1,
+                'userTitle' => $name,
+                'userTitleEnabled' => 0,
+                'disableJoinRequests' => 1,
+                'disableLeave' => 0,
+            ]);
+            // Resolves a group page by its slug. @see NodeBB `groups/create.js`
+            $groupSlugs[$this->slugify($name, 'group')] = $name;
+            $this->sortedSetAdd('groups:createtime', $name, $now);
+            $this->sortedSetAdd('groups:visible:createtime', $name, $now);
+            $this->sortedSetAdd('groups:visible:name', strtolower($name) . ':' . $name, 0);
+            // Counted in groupCounts(), which owns the `groups:visible:memberCount` entry: a
+            // second write of the same {_key,value} pair breaks NodeBB's unique index.
+            $this->memberCounts[$name] = 0;
+        }
+
+        // Memberships (join to resolve the group name from the role ID).
+        $members = $this->porterQB()->from('UserRole')
+            ->leftJoin('Role', 'UserRole.RoleID', '=', 'Role.RoleID')
+            ->select(['UserRole.UserID', 'Role.Name'])
+            ->cursor();
+        $seenMember = [];
+        foreach ($members as $member) {
+            $name = (string)$member->Name;
+            $uid = $this->uid((int)$member->UserID);
+            // Skip orphaned roles, roles not created here, and duplicate memberships (unique {_key,value}).
+            if ($name === '' || !isset($groupSlugs[$this->slugify($name, 'group')])) {
+                continue;
+            }
+            if (isset($seenMember["$name:$uid"])) {
+                continue;
+            }
+            $seenMember["$name:$uid"] = true;
+            $this->sortedSetAdd("group:$name:members", $uid, $now);
+            $this->memberCounts[$name] = ($this->memberCounts[$name] ?? 0) + 1;
+        }
+
+        $this->setObjectFields('groupslug:groupname', $groupSlugs);
+    }
+
+    /**
+     * Write categories as `category:{cid}` hashes, plus the listing sorted sets.
+     */
+    protected function categories(): void
+    {
+        $rows = $this->porterQB()->from('Category')
+            ->select(['CategoryID', 'ParentCategoryID', 'Name', 'UrlCode', 'Description', 'Sort'])
+            ->where('CategoryID', '!=', -1) // Ignore Vanilla's root category.
+            ->cursor();
+        foreach ($rows as $category) {
+            $cid = $this->cid((int)$category->CategoryID);
+            // Vanilla's root parent is -1 (or null); NodeBB lists top-level categories under root cid 0.
+            $parentID = (int)$category->ParentCategoryID;
+            $parentCid = ($parentID > 0) ? $this->cid($parentID) : 0;
+            $order = (int)$category->Sort;
+            $name = (string)$category->Name;
+
+            $this->setObject("category:$cid", [
+                'cid' => $cid,
+                'name' => $name,
+                'slug' => "$cid/" . $this->slugify($name, (string)$cid),
+                'description' => (string)$category->Description,
+                'parentCid' => $parentCid,
+                'order' => $order,
+                'topic_count' => 0,
+                'post_count' => 0,
+                'disabled' => 0,
+            ]);
+            $this->sortedSetAdd('categories:cid', $cid, $order);
+            $this->sortedSetAdd("cid:$parentCid:children", $cid, $order);
+            $this->sortedSetAdd('categories:name', strtolower($name) . ':' . $cid, 0); // Admin search.
+            $this->grantCategoryPrivileges($cid);
+        }
+    }
+
+    /**
+     * Grant a migrated category the privileges NodeBB gives one it created itself.
+     *
+     * A privilege is a hidden system group named `cid:{cid}:privileges:{name}` whose members are
+     * the groups holding it. Without them NodeBB shows the category to nobody, admin included, so
+     * a migration that skips this produces a forum with invisible content.
+     * @see NodeBB `categories/create.js` and `privileges/categories.js`
+     *
+     * @param int $cid
+     */
+    protected function grantCategoryPrivileges(int $cid): void
+    {
+        $now = $this->now();
+        // Members hold their own set; moderators hold that plus more; guests a read-only subset.
+        $grants = array_fill_keys(self::PRIVILEGES_MOD, []);
+        foreach (self::PRIVILEGES_MEMBER as $privilege) {
+            $grants[$privilege] = self::PRIVILEGE_GRANTS['member'];
+        }
+        foreach (array_keys($grants) as $privilege) {
+            $grants[$privilege] = array_merge($grants[$privilege], self::PRIVILEGE_GRANTS['mod']);
+        }
+        foreach (self::PRIVILEGES_GUEST as $privilege) {
+            $grants[$privilege] = array_merge($grants[$privilege], self::PRIVILEGE_GRANTS['guest']);
+        }
+
+        foreach ($grants as $privilege => $members) {
+            $name = "cid:$cid:privileges:$privilege";
+            $this->setObject("group:$name", [
+                'name' => $name,
+                'slug' => $this->slugify($name, "cid-$cid"),
+                'description' => '',
+                'createtime' => $now,
+                'memberCount' => count($members),
+                'hidden' => 1,
+                'system' => 1,
+                'private' => 1,
+                'userTitle' => $name,
+                'userTitleEnabled' => 0,
+                'disableJoinRequests' => 0,
+                'disableLeave' => 0,
+            ]);
+            foreach ($members as $member) {
+                $this->sortedSetAdd("group:$name:members", $member, $now);
+            }
+        }
+    }
+
+    /**
+     * Write discussions as `topic:{tid}` hashes, their first post (mainPid), and the listing sorted sets.
+     *
+     * With 'Use Discussion Body' on, the OP is `Discussion.Body`, synthesized as a post.
+     * With it off the OP is already a `Comment` row, so just point `mainPid` at it and let
+     * comments() write it.
+     * @see Package::getDiscussionBodyMode()
+     */
+    protected function discussions(): void
+    {
+        $useBody = $this->getDiscussionBodyMode();
+        // Resolve before the first chunk: both are memoized & used inside the loop.
+        $mainPids = $useBody ? [] : $this->mainPids();
+        $this->attachmentsByPid(); // Primed here; writePost() appends the links.
+        $this->porterQB()->from('Discussion')
+            ->select([
+                'DiscussionID', 'CategoryID', 'InsertUserID', 'Name', 'Body', 'Format',
+                'CountViews', 'Closed', 'Announce', 'DateInserted', 'DateLastComment',
+            ])
+            ->chunkById(self::CHUNK_SIZE, function ($rows) use ($useBody, $mainPids) {
+                $this->writeTopics($rows, $useBody, $mainPids);
+            }, 'DiscussionID');
+    }
+
+    /**
+     * Write one chunk of discussions.
+     *
+     * @param iterable $rows
+     * @param bool $useBody Whether the OP arrives on the discussion record.
+     * @param array $mainPids DiscussionID => CommentID of its first post.
+     */
+    protected function writeTopics(iterable $rows, bool $useBody, array $mainPids): void
+    {
+        foreach ($rows as $topic) {
+            $discussionID = (int)$topic->DiscussionID;
+            $tid = $this->tid($discussionID);
+            $cid = $this->cid((int)$topic->CategoryID);
+            $uid = $this->uid((int)$topic->InsertUserID);
+            $timestamp = $this->toMillis($topic->DateInserted);
+            $lastposttime = $this->toMillis($topic->DateLastComment) ?: $timestamp;
+            $views = (int)$topic->CountViews;
+            $title = (string)$topic->Name;
+            $mainPid = $this->opPid($discussionID);
+
+            $this->setObject("topic:$tid", [
+                'tid' => $tid,
+                'uid' => $uid,
+                'cid' => $cid,
+                'title' => $title,
+                'slug' => "$tid/" . $this->slugify($title, (string)$tid),
+                'mainPid' => $mainPid,
+                'teaserPid' => $mainPid, // Category rows read this; no replies are teased yet.
+                'timestamp' => $timestamp,
+                'lastposttime' => $lastposttime,
+                'postcount' => 1,
+                'viewcount' => $views,
+                'postercount' => 1,
+                'votes' => 0,
+                'locked' => (int)$topic->Closed,
+                'pinned' => (int)$topic->Announce,
+                'deleted' => 0,
+            ]);
+            $this->sortedSetAdd('topics:tid', $tid, $timestamp);
+            $this->sortedSetAdd('topics:recent', $tid, $lastposttime);
+            $this->sortedSetAdd('topics:views', $tid, $views);
+            $this->sortedSetAdd('topics:posts', $tid, 0);
+            $this->sortedSetAdd('topics:votes', $tid, 0);
+            $this->sortedSetAdd("cid:$cid:tids", $tid, $timestamp);
+            $this->sortedSetAdd("cid:$cid:tids:create", $tid, $timestamp);
+            $this->sortedSetAdd("cid:$cid:tids:lastposttime", $tid, $lastposttime);
+            $this->sortedSetAdd("cid:$cid:tids:views", $tid, $views);
+            $this->sortedSetAdd("cid:$cid:tids:posts", $tid, 0);
+            $this->sortedSetAdd("cid:$cid:tids:votes", $tid, 0);
+            $this->sortedSetAdd("cid:$cid:uid:$uid:tids", $tid, $timestamp);
+            $this->sortedSetAdd("uid:$uid:topics", $tid, $timestamp);
+            $this->sortedSetAdd("tid:$tid:posters", $uid, 1);
+
+            if ($useBody) {
+                // The first post carries the topic body.
+                $content = $this->formatContent($topic->Format, $topic->Body);
+                $this->writePost($mainPid, $tid, $cid, $uid, $content, $timestamp, false);
+            }
+        }
+    }
+
+    /**
+     * Write comments as `post:{pid}` hashes, plus the listing sorted sets.
+     */
+    protected function comments(): void
+    {
+        // Resolve before opening the cursor: the porter connection is unbuffered,
+        // so no other query may run while a cursor is active.
+        $this->pidOffset();
+        $useBody = $this->getDiscussionBodyMode();
+        $mainPids = $useBody ? [] : $this->mainPids();
+        $this->attachmentsByPid(); // Primed here; writePost() appends the links.
+        // Chunk rather than cursor: a single cursor over every comment grows the heap past the
+        // memory limit. `Storage::store()` favors a cursor, but writes one row where this fans a
+        // comment out to several documents.
+        $this->porterQB()->from('Comment')
+            ->leftJoin('Discussion', 'Comment.DiscussionID', '=', 'Discussion.DiscussionID')
+            ->select([
+                'Comment.CommentID', 'Comment.DiscussionID', 'Comment.InsertUserID',
+                'Comment.Body', 'Comment.Format', 'Comment.DateInserted', 'Discussion.CategoryID',
+            ])
+            ->chunkById(self::CHUNK_SIZE, function ($rows) use ($useBody, $mainPids) {
+                $this->writeComments($rows, $useBody, $mainPids);
+            }, 'Comment.CommentID', 'CommentID');
+    }
+
+    /**
+     * Write one chunk of comments.
+     *
+     * @param iterable $rows
+     * @param bool $useBody Whether the OP arrived on the discussion record.
+     * @param array $mainPids DiscussionID => CommentID of its first post.
+     */
+    protected function writeComments(iterable $rows, bool $useBody, array $mainPids): void
+    {
+        foreach ($rows as $comment) {
+            $commentID = (int)$comment->CommentID;
+            $discussionID = (int)$comment->DiscussionID;
+            $pid = $this->pid($commentID);
+            $tid = $this->tid($discussionID);
+            $cid = $this->cid((int)$comment->CategoryID);
+            $uid = $this->uid((int)$comment->InsertUserID);
+            $timestamp = $this->toMillis($comment->DateInserted);
+            // With the body mode off one of these comments IS the OP, so it must not list as a reply.
+            $isReply = $useBody || $commentID !== ($mainPids[$discussionID] ?? 0);
+            $content = $this->formatContent($comment->Format, $comment->Body);
+
+            $this->writePost($pid, $tid, $cid, $uid, $content, $timestamp, $isReply);
+        }
+    }
+
+    /**
+     * A post body as NodeBB stores it.
+     *
+     * Markdown stays raw so NodeBB's own renderer handles it (mentions, emoji); other formats are
+     * rendered to HTML, which NodeBB also accepts.
+     *
+     * @param ?string $format
+     * @param ?string $body
+     * @return string
+     */
+    protected function formatContent(?string $format, ?string $body): string
+    {
+        if (strtolower((string)$format) === 'markdown') {
+            return (string)$body;
+        }
+        return Formatter::instance()->toHtml($format, $body);
+    }
+
+    /**
+     * Map of DiscussionID => pid of its first post, for when the OP is a `Comment` row.
+     *
+     * `Discussion.FirstCommentID` is only populated by a handful of sources, so derive it from the
+     * lowest CommentID per discussion instead. Memoized because discussions() and comments() must
+     * agree on which post is the OP.
+     *
+     * @todo In-memory map sized to the discussion count.
+     * @return array
+     */
+    protected function mainPids(): array
+    {
+        if ($this->mainPids === null) {
+            $this->mainPids = [];
+            $rows = $this->porterQB()->from('Comment')
+                ->select('DiscussionID')
+                ->selectRaw('min(CommentID) as FirstPid')
+                ->groupBy('DiscussionID')
+                ->get();
+            foreach ($rows as $row) {
+                $this->mainPids[(int)$row->DiscussionID] = (int)$row->FirstPid;
+            }
+        }
+        return $this->mainPids;
+    }
+
+    /**
+     * Write a single `post:{pid}` hash and its listing sorted sets.
+     *
+     * @param int $pid
+     * @param int $tid
+     * @param int $cid
+     * @param int $uid
+     * @param string $content
+     * @param int $timestamp Milliseconds since epoch.
+     * @param bool $isReply Replies join `tid:{tid}:posts`; the first post (mainPid) does not.
+     */
+    protected function writePost(
+        int $pid,
+        int $tid,
+        int $cid,
+        int $uid,
+        string $content,
+        int $timestamp,
+        bool $isReply
+    ): void {
+        $this->setObject("post:$pid", [
+            'pid' => $pid,
+            'tid' => $tid,
+            'uid' => $uid,
+            'content' => $content . $this->attachmentLinks($pid),
+            'timestamp' => $timestamp,
+            'deleted' => 0,
+        ]);
+        $this->sortedSetAdd('posts:pid', $pid, $timestamp);
+        $this->sortedSetAdd('posts:votes', $pid, 0);
+        $this->sortedSetAdd("uid:$uid:posts", $pid, $timestamp);
+        $this->sortedSetAdd("cid:$cid:pids", $pid, $timestamp);
+        $this->sortedSetAdd("cid:$cid:uid:$uid:pids", $pid, $timestamp);
+        if ($isReply) {
+            $this->sortedSetAdd("tid:$tid:posts", $pid, $timestamp);
+            $this->sortedSetAdd("tid:$tid:posts:votes", $pid, 0);
+        }
+    }
+
+    /**
+     * Write attachments as `upload:{md5}` hashes, plus the sorted sets tying them to their post
+ * and uploader.
+     *
+     * NodeBB has no attachment records of its own: an upload is the file on disk, a hash keyed on
+     * its path, and a link in the post content (which writePost() appends). We reproduce what
+     * `Posts.uploads.associate()` and `User.associateUpload()` write.
+     *
+     * @see https://github.com/NodeBB/NodeBB/blob/master/src/posts/uploads.js
+     */
+    protected function attachments(): void
+    {
+        if (!$this->hasPortSchema('Media')) {
+            Log::comment('Skipping import: Attachments (Source lacks support)');
+            return;
+        }
+        $postUploads = [];
+        foreach ($this->attachmentsByPid() as $pid => $attachments) {
+            $paths = [];
+            foreach ($attachments as $attachment) {
+                $key = 'upload:' . md5($attachment['path']);
+                $paths[] = $attachment['path'];
+
+                // Image dimensions are all NodeBB stores here. @see `Posts.uploads.saveSize()`
+                $upload = ['uid' => $attachment['uid']];
+                if ($attachment['width'] && $attachment['height']) {
+                    $upload['width'] = $attachment['width'];
+                    $upload['height'] = $attachment['height'];
+                }
+                $this->setObject($key, $upload);
+                $this->sortedSetAdd("$key:pids", $pid, $attachment['timestamp']);
+                $this->sortedSetAdd(
+                    "uid:{$attachment['uid']}:uploads",
+                    $attachment['path'],
+                    $attachment['timestamp']
+                );
+            }
+            // NodeBB stores this as a JSON string, not an array. @see `Posts.uploads.associate()`
+            $postUploads["post:$pid"] = ['uploads' => json_encode($paths)];
+        }
+        if (!empty($postUploads)) {
+            $this->setObjectFieldsBulk($postUploads);
+        }
+    }
+
+    /**
+     * Map of pid => list of its attachments.
+     *
+     * Keyed on the pid so writePost() can append links as it streams. Built from `Media.Path`, the
+     * same value the file transfer copies to, so the records hold whether or not files are moved.
+     *
+     * @todo In-memory map sized to the attachment count.
+     * @return array
+     */
+    protected function attachmentsByPid(): array
+    {
+        if ($this->attachmentsByPid !== null) {
+            return $this->attachmentsByPid;
+        }
+        $this->attachmentsByPid = [];
+        if (!$this->hasPortSchema('Media')) {
+            return $this->attachmentsByPid; // Reported by attachments().
+        }
+
+        $rows = $this->porterQB()->from('Media')
+            ->select([
+                'Name', 'Path', 'Type', 'ForeignID', 'ForeignTable',
+                'InsertUserID', 'DateInserted', 'ImageWidth', 'ImageHeight',
+            ])
+            ->whereNotNull('Path')
+            ->get();
+        foreach ($rows as $media) {
+            $pid = $this->resolveAttachmentPid((string)$media->ForeignTable, (int)$media->ForeignID);
+            if (!$pid) {
+                continue; // Attached to something this target doesn't migrate (e.g. a PM or an embed).
+            }
+            $this->attachmentsByPid[$pid][] = [
+                'path' => self::ATTACHMENT_PATH . '/' . ltrim((string)$media->Path, '/'),
+                'name' => (string)$media->Name,
+                'type' => (string)$media->Type,
+                'uid' => $this->uid((int)$media->InsertUserID),
+                'timestamp' => $this->toMillis($media->DateInserted),
+                'width' => (int)$media->ImageWidth,
+                'height' => (int)$media->ImageHeight,
+            ];
+        }
+
+        return $this->attachmentsByPid;
+    }
+
+    /**
+     * Find the pid an attachment belongs to, or 0 if its parent wasn't migrated.
+     *
+     * Sources disagree on the case of `Media.ForeignTable` and also use it for records with no post
+     * (e.g. 'embed', 'message'), so match case-insensitively and ignore the rest.
+     *
+     * @param string $foreignTable
+     * @param int $foreignID
+     * @return int
+     */
+    protected function resolveAttachmentPid(string $foreignTable, int $foreignID): int
+    {
+        return match (strtolower($foreignTable)) {
+            'discussion' => $this->opPid($foreignID),
+            'comment' => $this->pid($foreignID),
+            default => 0,
+        };
+    }
+
+    /**
+     * Render a post's attachments as content, since that is the only place NodeBB shows them.
+     *
+     * HTML rather than Markdown because it survives either renderer.
+     *
+     * @param int $pid
+     * @return string
+     */
+    protected function attachmentLinks(int $pid): string
+    {
+        $links = '';
+        foreach ($this->attachmentsByPid()[$pid] ?? [] as $attachment) {
+            $url = self::UPLOADS_WEB_PATH . $attachment['path'];
+            $name = htmlspecialchars($attachment['name'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $links .= str_starts_with($attachment['type'], 'image/')
+                ? '<p><img src="' . $url . '" alt="' . $name . '" /></p>'
+                : '<p><a href="' . $url . '">' . $name . '</a></p>';
+        }
+        return $links;
+    }
+
+    /**
+     * Aggregates NodeBB reads, totaled once everything else is written.
+     *
+     * Counts come from the relational `PORT_` data so the document engine stays write-only.
+     */
+    protected function cleanup(): void
+    {
+        $this->topicCounts();
+        $this->categoryCounts();
+        $this->userCounts();
+        $this->groupCounts();
+        $this->globals();
+
+        // Index `_key` once the bulk load is done so the updates above don't scan the collection.
+        $this->mongo()->flush();
+        $this->indexObjects();
+    }
+
+    /**
+     * How many posts each discussion contributes on top of its `PORT_Comment` rows.
+     *
+     * With the body mode on a first post was synthesized from `Discussion.Body`, so every topic is
+     * worth one more post than it has comments. With it off the OP is already a comment and counting
+     * it again would inflate every total.
+     *
+     * @return int
+     */
+    protected function firstPostCount(): int
+    {
+        return $this->getDiscussionBodyMode() ? 1 : 0;
+    }
+
+    /**
+     * Set `topic.postcount` to its replies plus the first post.
+     */
+    protected function topicCounts(): void
+    {
+        $rows = $this->porterQB()->from('Comment')
+            ->select('DiscussionID')
+            ->selectRaw('count(*) as found_count')
+            ->groupBy('DiscussionID')
+            ->get();
+        $firstPost = $this->firstPostCount();
+        $updates = [];
+        foreach ($rows as $row) {
+            $tid = $this->tid((int)$row->DiscussionID);
+            $updates["topic:$tid"] = ['postcount' => (int)$row->found_count + $firstPost];
+        }
+        $this->setObjectFieldsBulk($updates);
+    }
+
+    /**
+     * Set `category.topic_count` and `category.post_count` (first posts + replies).
+     */
+    protected function categoryCounts(): void
+    {
+        $topicCounts = [];
+        // Join Category so a discussion pointing at an unmigrated category cannot land its
+        // count on an install category that happens to occupy the same offset ID.
+        $topicRows = $this->porterQB()->from('Discussion')
+            ->join('Category', 'Category.CategoryID', '=', 'Discussion.CategoryID')
+            ->select('Discussion.CategoryID')
+            ->selectRaw('count(*) as found_count')
+            ->where('Category.CategoryID', '!=', -1)
+            ->groupBy('Discussion.CategoryID')
+            ->get();
+        foreach ($topicRows as $row) {
+            $topicCounts[(int)$row->CategoryID] = (int)$row->found_count;
+        }
+
+        $commentCounts = [];
+        $commentRows = $this->porterQB()->from('Comment')
+            ->join('Discussion', 'Comment.DiscussionID', '=', 'Discussion.DiscussionID')
+            ->join('Category', 'Category.CategoryID', '=', 'Discussion.CategoryID')
+            ->select('Discussion.CategoryID')
+            ->selectRaw('count(*) as found_count')
+            ->where('Category.CategoryID', '!=', -1)
+            ->groupBy('Discussion.CategoryID')
+            ->get();
+        foreach ($commentRows as $row) {
+            $commentCounts[(int)$row->CategoryID] = (int)$row->found_count;
+        }
+
+        $firstPost = $this->firstPostCount();
+        $updates = [];
+        foreach ($topicCounts as $categoryID => $topics) {
+            $cid = $this->cid($categoryID);
+            $updates["category:$cid"] = [
+                'topic_count' => $topics,
+                'post_count' => ($topics * $firstPost) + ($commentCounts[$categoryID] ?? 0),
+            ];
+        }
+        $this->setObjectFieldsBulk($updates);
+    }
+
+    /**
+     * Set `user.topiccount` and `user.postcount` (first posts + replies).
+     */
+    protected function userCounts(): void
+    {
+        $topicCounts = [];
+        $topicRows = $this->porterQB()->from('Discussion')
+            ->select('InsertUserID')
+            ->selectRaw('count(*) as found_count')
+            ->groupBy('InsertUserID')
+            ->get();
+        foreach ($topicRows as $row) {
+            $topicCounts[(int)$row->InsertUserID] = (int)$row->found_count;
+        }
+
+        $commentCounts = [];
+        $commentRows = $this->porterQB()->from('Comment')
+            ->select('InsertUserID')
+            ->selectRaw('count(*) as found_count')
+            ->groupBy('InsertUserID')
+            ->get();
+        foreach ($commentRows as $row) {
+            $commentCounts[(int)$row->InsertUserID] = (int)$row->found_count;
+        }
+
+        $firstPost = $this->firstPostCount();
+        $userIDs = array_unique(array_merge(array_keys($topicCounts), array_keys($commentCounts)));
+        $updates = [];
+        foreach ($userIDs as $userID) {
+            $uid = $this->uid($userID);
+            $topics = $topicCounts[$userID] ?? 0;
+            $updates["user:$uid"] = [
+                'topiccount' => $topics,
+                'postcount' => ($topics * $firstPost) + ($commentCounts[$userID] ?? 0),
+            ];
+        }
+        $this->setObjectFieldsBulk($updates);
+    }
+
+    /**
+     * Set `group.memberCount`, which NodeBB shows and sorts on but never recalculates.
+     *
+     * `registered-users` already had the install's own members, so add to what is there.
+     */
+    protected function groupCounts(): void
+    {
+        foreach ($this->memberCounts as $name => $migrated) {
+            $existing = (int)($this->getObject("group:$name")['memberCount'] ?? 0);
+            $total = ($name === self::GROUP_REGISTERED) ? $existing + $migrated : $migrated;
+            $this->setObjectFields("group:$name", ['memberCount' => $total]);
+            $this->sortedSetUpdate('groups:visible:memberCount', $name, $total);
+        }
+    }
+
+    /**
+     * Advance the `next*` counters and totals NodeBB reads on boot, past the migrated records.
+     */
+    protected function globals(): void
+    {
+        $topicCount = $this->porterQB()->from('Discussion')->count();
+        $commentCount = $this->porterQB()->from('Comment')->count();
+        $global = $this->getObject('global') ?? [];
+        $posts = ($topicCount * $this->firstPostCount()) + $commentCount;
+
+        $this->setObjectFields('global', [
+            // Set to the highest id assigned; NodeBB increments before using it.
+            'nextUid' => $this->uid((int)$this->porterQB()->from('User')->max('UserID')),
+            'nextCid' => $this->cid((int)$this->porterQB()->from('Category')->max('CategoryID')),
+            'nextTid' => $this->tid((int)$this->porterQB()->from('Discussion')->max('DiscussionID')),
+            'nextPid' => $this->maxPid(),
+            // Totals include whatever the target install already had.
+            'userCount' => (int)($global['userCount'] ?? 0) + $this->porterQB()->from('User')->count(),
+            'categoryCount' => (int)($global['categoryCount'] ?? 0)
+                + $this->porterQB()->from('Category')->count(),
+            'topicCount' => (int)($global['topicCount'] ?? 0) + $topicCount,
+            'postCount' => (int)($global['postCount'] ?? 0) + $posts,
+        ]);
+    }
+
+    /**
+     * Highest pid this migration assigned, across both ways the OP can arrive.
+     *
+     * @return int
+     */
+    protected function maxPid(): int
+    {
+        $maxComment = (int)$this->porterQB()->from('Comment')->max('CommentID');
+        $maxDiscussion = (int)$this->porterQB()->from('Discussion')->max('DiscussionID');
+
+        return max(
+            $maxComment ? $this->pid($maxComment) : 0,
+            $this->getDiscussionBodyMode() ? $this->offset('pid') + $maxDiscussion : 0,
+            $this->offset('pid')
+        );
+    }
+
+    /**
+     * Assign a new location for message file attachments.
+     *
+     * Format: {approot}/public/uploads/files/{Media.Path}
+     * Reuses `Path` so the file lands where attachments() already pointed the upload records.
+     * Unlike a SQL target the output store is MongoDB, so this updates `PORT_` on the porter
+     * (SQL) connection.
+     * @see self::filemap()
+     * @see self::SUPPORTED [attachmentPath]
+     */
+    protected function mapAttachments(string $fileTarget): int
+    {
+        $rows = 0;
+        $attachments = $this->porterQB()->from('Media')
+            ->select(['MediaID'])
+            ->selectRaw("concat('{$fileTarget}/', trim(leading '/' from Path)) as TargetFullPath")
+            ->whereNotNull('Path')
+            ->get();
+        foreach ($attachments as $attachment) {
+            $rows += $this->dbPorter()->affectingStatement("update `PORT_Media`
+                set TargetFullPath = " . $this->dbPorter()->escape($attachment->TargetFullPath) . "
+                where MediaID = {$attachment->MediaID}");
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Assign a new location for user photos / avatars.
+     *
+     * Format: {approot}/public/uploads/profile/{original filename}
+     * Unlike a SQL target the output store is MongoDB, so this updates `PORT_` on the porter
+     * (SQL) connection. users() then reads the mapped path back to set the NodeBB `picture`.
+     * @see self::filemap()
+     * @see self::SUPPORTED [avatarPath]
+     */
+    protected function mapAvatars(string $fileTarget): int
+    {
+        $rows = 0;
+        $avatars = $this->porterQB()->from('User')
+            ->select(['UserID'])
+            ->selectRaw("concat('{$fileTarget}/', substring_index(Photo, '/', -1)) as TargetAvatarFullPath")
+            ->whereNotNull('SourceAvatarFullPath')
+            ->whereNotNull('Photo')
+            ->get();
+        foreach ($avatars as $avatar) {
+            $rows += $this->dbPorter()->affectingStatement("update `PORT_User`
+                set TargetAvatarFullPath = " . $this->dbPorter()->escape($avatar->TargetAvatarFullPath) . "
+                where UserID = {$avatar->UserID}");
+        }
+
+        return $rows;
+    }
+
+    /**
+     * The output storage, typed for the document primitives.
+     *
+     * @return Mongo
+     */
+    protected function mongo(): Mongo
+    {
+        assert($this->outputStorage instanceof Mongo);
+        return $this->outputStorage;
+    }
+
+    /**
+     * NodeBB models Redis in Mongo: every hash and sorted set is a document in one collection.
+     * The methods below express that over the storage's generic primitives.
+     * @see https://github.com/NodeBB/NodeBB/tree/master/src/database/mongo
+     */
+
+    /**
+     * Write a hash object (e.g. `user:1`) as a single `{_key, ...fields}` document.
+     *
+     * @param string $key The object's `_key`.
+     * @param array $fields Name => value.
+     */
+    protected function setObject(string $key, array $fields): void
+    {
+        $this->mongo()->insert(self::OBJECTS, array_merge(['_key' => $key], $fields));
+    }
+
+    /**
+     * Read a hash object back, for the few cases that must not overwrite what NodeBB already has.
+     *
+     * @param string $key The object's `_key`.
+     * @return array|null Null if no such object.
+     */
+    protected function getObject(string $key): ?array
+    {
+        return $this->mongo()->findOne(self::OBJECTS, ['_key' => $key]);
+    }
+
+    /**
+     * Merge fields into one hash object, creating it if the install has no such record.
+     *
+     * @param string $key The object's `_key`.
+     * @param array $fields Name => value.
+     */
+    protected function setObjectFields(string $key, array $fields): void
+    {
+        if (empty($fields)) {
+            return;
+        }
+        $this->mongo()->updateOne(self::OBJECTS, ['_key' => $key], ['$set' => $fields], true);
+    }
+
+    /**
+     * Set fields on many existing hash objects in one batched pass. Does not upsert.
+     *
+     * @param array $updates Map of `_key` => [field => value].
+     */
+    protected function setObjectFieldsBulk(array $updates): void
+    {
+        $operations = [];
+        foreach ($updates as $key => $fields) {
+            $operations[] = ['updateOne' => [['_key' => $key], ['$set' => $fields]]];
+        }
+        $this->mongo()->bulkWrite(self::OBJECTS, $operations);
+    }
+
+    /**
+     * Add a member to a sorted set (e.g. `cid:1:tids`) as a `{_key, value, score}` document.
+     *
+     * @param string $key The sorted set's `_key`.
+     * @param int|string $value The member.
+     * @param int|float $score The sort score.
+     */
+    protected function sortedSetAdd(string $key, int|string $value, int|float $score): void
+    {
+        $this->mongo()->insert(self::OBJECTS, ['_key' => $key, 'value' => (string)$value, 'score' => $score]);
+    }
+
+    /**
+     * Add or re-score one sorted set member, for values revised after the bulk load.
+     *
+     * `sortedSetAdd()` buffers a plain insert; a second write of the same {_key,value} would break
+     * the unique index NodeBB builds on boot, so revisions upsert instead.
+     *
+     * @param string $key The sorted set's `_key`.
+     * @param int|string $value The member.
+     * @param int|float $score The sort score.
+     */
+    protected function sortedSetUpdate(string $key, int|string $value, int|float $score): void
+    {
+        $this->mongo()->updateOne(
+            self::OBJECTS,
+            ['_key' => $key, 'value' => (string)$value],
+            ['$set' => ['score' => $score]],
+            true
+        );
+    }
+
+    /**
+     * Index the objects collection on `_key` so lookups and updates don't scan the collection.
+     *
+     * NodeBB rebuilds its full index set on upgrade; this just keeps the migration itself fast.
+     */
+    protected function indexObjects(): void
+    {
+        $this->mongo()->createIndex(self::OBJECTS, ['_key' => 1]);
+    }
+
+    /**
+     * Offset applied to comment IDs to reach this migration's pid space.
+     *
+     * Always clears the posts the target install already has. With the body mode on it clears the
+     * synthesized first posts too, which occupy one pid per discussion directly above those.
+     *
+     * @return int
+     */
+    protected function pidOffset(): int
+    {
+        if ($this->pidOffset === null) {
+            $this->pidOffset = $this->offset('pid') + ($this->getDiscussionBodyMode()
+                ? (int)$this->porterQB()->from('Discussion')->max('DiscussionID')
+                : 0);
+        }
+        return $this->pidOffset;
+    }
+
+    /**
+     * Convert a SQL datetime to milliseconds since epoch (NodeBB's time format).
+     *
+     * @param mixed $datetime
+     * @return int
+     */
+    protected function toMillis(mixed $datetime): int
+    {
+        if (empty($datetime)) {
+            return 0;
+        }
+        $timestamp = strtotime((string)$datetime);
+        return ($timestamp === false) ? 0 : $timestamp * 1000;
+    }
+
+    /**
+     * Current time in milliseconds since epoch.
+     *
+     * @return int
+     */
+    protected function now(): int
+    {
+        return (int)(microtime(true) * 1000);
+    }
+
+    /**
+     * Slug a value the way NodeBB does (lowercase, non-alphanumerics to single dashes).
+     *
+     * NodeBB transliterates; this only strips. A name with no ASCII letters at all (Cyrillic, CJK,
+     * Greek) would otherwise slug to '' and leave the record unreachable by URL, so fall back to the
+     * record's ID. Ugly, but addressable.
+     *
+     * @param string $value
+     * @param string $fallback Used when $value holds nothing sluggable.
+     * @return string
+     */
+    protected function slugify(string $value, string $fallback = ''): string
+    {
+        $slug = trim((string)preg_replace('/[^a-z0-9]+/', '-', strtolower($value)), '-');
+
+        return ($slug === '') ? $fallback : $slug;
+    }
+}

--- a/tests/integration/AttachmentsTest.php
+++ b/tests/integration/AttachmentsTest.php
@@ -1,0 +1,299 @@
+<?php
+
+use Illuminate\Database\Query\Builder;
+use PHPUnit\Framework\TestCase;
+use Porter\Config;
+use Porter\Factory;
+use Porter\Storage;
+use Porter\Target;
+
+/**
+ * The file-mapping contract every attachment-capable Target must honor.
+ *
+ * `filemap()` is shared, but each Target names its own destination, so assert the behavior they
+ * have to agree on rather than the paths they don't.
+ *
+ * NOTE: this rebuilds the `PORT_` tables on the test connection, same as a real migration would.
+ */
+class AttachmentsTest extends TestCase
+{
+    /** @var string Connection the tests run against, from `test_alias`. */
+    protected static string $alias = '';
+
+    /** @var string|null Why these tests cannot safely run here. @see self::findUnsafeAlias() */
+    protected static ?string $skip = null;
+
+    /** @var string Stands in for the target install's root during mapping. */
+    public const TARGET_ROOT = '/srv/target';
+
+    /** @var string Stands in for the source install's upload folder. */
+    public const SOURCE_UPLOADS = '/srv/source/uploads';
+
+    /**
+     * Shared fixture that runs exactly once prior to ALL the tests in this class.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        $config = loadConfig();
+        self::$alias = $config['test_alias'] ?? '';
+        self::$skip = self::findUnsafeAlias($config, self::$alias);
+        if (self::$skip !== null) {
+            return; // Nothing is seeded, because seeding is what would do the damage.
+        }
+
+        // `getPath('attachment', 'full')` reads this to build an absolute destination.
+        // Config::set() replaces wholesale, so put the loaded config back alongside it.
+        Config::getInstance()->set(array_merge($config, ['target_root' => self::TARGET_ROOT]));
+
+        self::seed(Factory::storage(self::$alias, 'PORT_'));
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$skip !== null) {
+            $this->markTestSkipped(self::$skip);
+        }
+    }
+
+    /**
+     * Why this connection must not be written to, or null if it is safe.
+     *
+     * These tests rebuild `PORT_` tables, so pointing them at a connection that holds real
+     * migration data destroys it. Refuse rather than trust the operator to have read a comment.
+     *
+     * @param array $config
+     * @param string $alias
+     * @return string|null
+     */
+    protected static function findUnsafeAlias(array $config, string $alias): ?string
+    {
+        if ($alias === '') {
+            return 'Set `test_alias` in config.php to a connection reserved for tests.';
+        }
+        $live = array_filter([
+            'input_alias' => $config['input_alias'] ?? null,
+            'output_alias' => $config['output_alias'] ?? null,
+            'porter_alias' => $config['porter_alias'] ?? null,
+        ]);
+        $clash = array_search($alias, $live, true);
+        if ($clash !== false) {
+            return "`test_alias` is '$alias', which is also `$clash`. These tests rebuild tables, "
+                . 'so point `test_alias` at a database reserved for them.';
+        }
+
+        return null;
+    }
+
+    /**
+     * Build the `PORT_` tables from Porter's own structure, then fill in one topic and its files.
+     *
+     * Attachments cover the cases Targets have to tell apart: one on the discussion, one on the
+     * comment, one with no source file, and one attached to a record Targets don't migrate.
+     *
+     * @param Storage $storage
+     */
+    protected static function seed(Storage $storage): void
+    {
+        $structure = loadData('structure');
+        foreach (['User', 'Category', 'Discussion', 'Comment', 'Media'] as $table) {
+            $storage->prepare($table, $structure[$table]);
+        }
+
+        $db = $storage->getHandle();
+        $db->table('User')->insert([
+            'UserID' => 1,
+            'Name' => 'Linc',
+            'Email' => 'lincoln@example.com',
+            'Password' => 'hash',
+            'Photo' => 'userpics/avatar.jpg',
+            'DateInserted' => '2020-01-01 00:00:00',
+            'DateLastActive' => '2020-06-01 00:00:00',
+            'SourceAvatarFullPath' => self::SOURCE_UPLOADS . '/userpics/avatar.jpg',
+        ]);
+        $db->table('Category')->insert([
+            'CategoryID' => 1, 'Name' => 'General', 'UrlCode' => 'general', 'Sort' => 1,
+        ]);
+        $db->table('Discussion')->insert([
+            'DiscussionID' => 1,
+            'CategoryID' => 1,
+            'InsertUserID' => 1,
+            'Name' => 'Hello World',
+            'Body' => 'This is the [b]opening[/b] post.',
+            'Format' => 'BBCode',
+            'CountViews' => 7,
+            'DateInserted' => '2020-02-01 00:00:00',
+            'DateLastComment' => '2020-02-02 00:00:00',
+        ]);
+        $db->table('Comment')->insert([
+            'CommentID' => 1,
+            'DiscussionID' => 1,
+            'InsertUserID' => 1,
+            'Body' => 'This is a reply.',
+            'Format' => 'BBCode',
+            'DateInserted' => '2020-02-02 00:00:00',
+        ]);
+        // Every row needs the same keys in the same order for a bulk insert.
+        $media = [
+            [   // On the discussion (the OP).
+                'MediaID' => 1,
+                'Name' => 'report.pdf',
+                'Path' => 'attachments/report.pdf',
+                'Type' => 'application/pdf',
+                'DateInserted' => '2020-02-01 00:00:00',
+                'ForeignID' => 1,
+                'ForeignTable' => 'discussion',
+                'ImageWidth' => null,
+                'ImageHeight' => null,
+                'SourceFullPath' => self::SOURCE_UPLOADS . '/attachments/report.pdf',
+            ],
+            [   // On the comment, & an image so dimensions can carry over.
+                'MediaID' => 2,
+                'Name' => 'photo.png',
+                'Path' => 'attachments/photo.png',
+                'Type' => 'image/png',
+                'DateInserted' => '2020-02-02 00:00:00',
+                'ForeignID' => 1,
+                'ForeignTable' => 'Comment', // Sources disagree on the case.
+                'ImageWidth' => 640,
+                'ImageHeight' => 480,
+                'SourceFullPath' => self::SOURCE_UPLOADS . '/attachments/photo.png',
+            ],
+            [   // No source file, so there is nothing to transfer & nothing to map.
+                'MediaID' => 3,
+                'Name' => 'missing.zip',
+                'Path' => 'attachments/missing.zip',
+                'Type' => 'application/zip',
+                'DateInserted' => '2020-02-03 00:00:00',
+                'ForeignID' => 1,
+                'ForeignTable' => 'comment',
+                'ImageWidth' => null,
+                'ImageHeight' => null,
+                'SourceFullPath' => null,
+            ],
+            [   // Attached to a record none of these Targets migrate.
+                'MediaID' => 4,
+                'Name' => 'embedded.gif',
+                'Path' => 'attachments/embedded.gif',
+                'Type' => 'image/gif',
+                'DateInserted' => '2020-02-04 00:00:00',
+                'ForeignID' => 99,
+                'ForeignTable' => 'embed',
+                'ImageWidth' => null,
+                'ImageHeight' => null,
+                'SourceFullPath' => self::SOURCE_UPLOADS . '/attachments/embedded.gif',
+            ],
+        ];
+        $db->table('Media')->insert(array_map(fn($row) => $row + ['InsertUserID' => 1], $media));
+    }
+
+    /**
+     * Every Target declaring attachment support, so new ones get held to this too.
+     *
+     * @return array
+     */
+    public static function getAttachmentTargets(): array
+    {
+        $targets = [];
+        foreach (loadData('targets') as $name) {
+            $support = ('\Porter\Target\\' . $name)::getSupport();
+            if (!empty($support['attachmentPath']) && !empty($support['features']['Attachments'])) {
+                $targets[$name] = [$name];
+            }
+        }
+        return $targets;
+    }
+
+    /**
+     * @dataProvider getAttachmentTargets
+     */
+    public function testMapsEveryTransferableAttachment(string $name): void
+    {
+        $target = $this->mapAttachments($name);
+
+        // MediaID 1 and 2 have a source file; 4 does too, even though its parent isn't migrated.
+        // Targets differ on whether they also map MediaID 3, which has no source file to copy.
+        // That costs nothing, since FileTransfer needs both paths, so don't hold them to it.
+        $mapped = $this->getMedia()->whereNotNull('TargetFullPath')->pluck('MediaID')->all();
+        foreach ([1, 2, 4] as $mediaID) {
+            $this->assertContains(
+                $mediaID,
+                $mapped,
+                "$name should map every attachment holding a source file."
+            );
+        }
+
+        // The destination has to land inside the folder the Target advertises.
+        $attachmentPath = $target::getSupport()['attachmentPath'];
+        foreach ($this->getMedia()->whereNotNull('TargetFullPath')->pluck('TargetFullPath') as $path) {
+            $this->assertStringStartsWith(
+                self::TARGET_ROOT . '/' . $attachmentPath . '/',
+                $path,
+                "$name should map into its declared attachmentPath."
+            );
+        }
+    }
+
+    /**
+     * Two attachments sharing a destination means the transfer silently overwrites one of them.
+     *
+     * @dataProvider getAttachmentTargets
+     */
+    public function testMappedAttachmentsAreUnique(string $name): void
+    {
+        $this->mapAttachments($name);
+
+        $paths = $this->getMedia()->whereNotNull('TargetFullPath')->pluck('TargetFullPath')->all();
+        $this->assertSameSize($paths, array_unique($paths), "$name should give every attachment its own path.");
+    }
+
+    /**
+     * Attachments are only mapped as part of a file transfer.
+     *
+     * @dataProvider getAttachmentTargets
+     */
+    public function testSkipsMappingWithoutFileTransfer(string $name): void
+    {
+        $this->mapAttachments($name, false);
+
+        $this->assertEmpty(
+            $this->getMedia()->whereNotNull('TargetFullPath')->pluck('TargetFullPath')->all(),
+            "$name should map nothing when no file transfer is configured."
+        );
+    }
+
+    /**
+     * Run a Target's file mapping over the seeded attachments.
+     *
+     * @param string $name
+     * @param bool $transferFiles
+     * @return Target
+     */
+    protected function mapAttachments(string $name, bool $transferFiles = true): Target
+    {
+        $this->getMedia()->update(['TargetFullPath' => null]); // Reset between Targets.
+
+        $storage = Factory::storage(self::$alias, 'PORT_');
+        $target = Factory::target($name, $storage, $storage);
+        if ($transferFiles) {
+            $target->enableFileTransfer(); // Normally set by Controller::setFlags().
+        }
+
+        // `filemap()` is a MANIFEST step, so run() is the only way in during a real migration.
+        // Buffered because Log::comment() echoes its progress, which PHPUnit counts as risky.
+        ob_start();
+        new ReflectionMethod($target, 'filemap')->invoke($target);
+        ob_end_clean();
+
+        return $target;
+    }
+
+    /**
+     * A fresh query builder over the seeded attachments.
+     *
+     * @return Builder
+     */
+    protected function getMedia(): Builder
+    {
+        return Factory::storage(self::$alias, 'PORT_')->getHandle()->table('Media')->orderBy('MediaID');
+    }
+}

--- a/tests/integration/NodeBbTest.php
+++ b/tests/integration/NodeBbTest.php
@@ -1,0 +1,770 @@
+<?php
+
+use MongoDB\Database;
+use PHPUnit\Framework\TestCase;
+use Porter\Config;
+use Porter\Factory;
+use Porter\Storage;
+use Porter\Storage\Mongo;
+use Porter\Target\NodeBb;
+
+/**
+ * NodeBB's document shape, which nothing else in Porter writes.
+ *
+ * An upload in NodeBB is a file on disk, a hash keyed on the md5 of its path, sorted sets tying it
+ * to a post and an uploader, and a link in the post content. Assert we reproduce all four.
+ *
+ * NOTE: this rebuilds the `PORT_` tables on the test connection and drops the Mongo `objects`
+ * collection, same as a real migration would.
+ *
+ * @see https://github.com/NodeBB/NodeBB/blob/master/src/posts/uploads.js
+ */
+class NodeBbTest extends TestCase
+{
+    /** @var string Connection holding the `PORT_` tables. */
+    protected static string $porterAlias = 'test';
+
+    /** @var string Connection for the NodeBB document store, from `test_mongo_alias`. */
+    protected static string $mongoAlias = '';
+
+    /** @var string|null Why these tests cannot safely run here. @see self::findUnsafeAlias() */
+    protected static ?string $skip = null;
+
+    /** @var string Stands in for the target install's root during mapping. */
+    public const TARGET_ROOT = '/srv/target';
+
+    /** @var string Stands in for the source install's upload folder. */
+    public const SOURCE_UPLOADS = '/srv/source/uploads';
+
+    /** @var int The seeded discussion's opening post, as a Comment row. */
+    public const OP_COMMENT_ID = 50;
+
+    /** @var int The seeded discussion's one reply. */
+    public const REPLY_COMMENT_ID = 51;
+
+    /** @var int Offset applied to CommentIDs when the OP came off the discussion record. */
+    public const PID_OFFSET = 1; // max(DiscussionID)
+
+    /** @var int A UserRole pointing at a User row that does not exist. */
+    public const DELETED_USER_ID = 99;
+
+    /** @var int A seeded attachment with no source file to copy. */
+    public const UNTRANSFERABLE_MEDIA_ID = 3;
+
+    /** @var int A comment authored by user 0 (guest/authorless in Vanilla). */
+    public const GUEST_COMMENT_ID = 60;
+
+    /**
+     * Shared fixture that runs exactly once prior to ALL the tests in this class.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        $config = loadConfig();
+        self::$porterAlias = $config['test_alias'] ?? '';
+        // Named explicitly, never discovered: scanning for "a mongodb connection" finds the
+        // operator's real NodeBB, and these tests clear whatever they are pointed at.
+        self::$mongoAlias = $config['test_mongo_alias'] ?? '';
+        self::$skip = self::findUnsafeAlias($config);
+
+        // `getPath()` reads this to build an absolute destination.
+        // Config::set() replaces wholesale, so put the loaded config back alongside it.
+        Config::getInstance()->set(array_merge($config, ['target_root' => self::TARGET_ROOT]));
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$skip !== null) {
+            $this->markTestSkipped(self::$skip);
+        }
+    }
+
+    /**
+     * Why these connections must not be written to, or null if they are safe.
+     *
+     * These tests rebuild `PORT_` tables and clear the target Mongo database, so pointing them at
+     * anything holding real data destroys it. Refuse rather than trust a comment in the config.
+     *
+     * @param array $config
+     * @return string|null
+     */
+    protected static function findUnsafeAlias(array $config): ?string
+    {
+        if (self::$porterAlias === '') {
+            return 'Set `test_alias` in config.php to a connection reserved for tests.';
+        }
+        if (self::$mongoAlias === '') {
+            return 'Set `test_mongo_alias` in config.php to a Mongo database reserved for tests.';
+        }
+        $live = array_filter([
+            'input_alias' => $config['input_alias'] ?? null,
+            'output_alias' => $config['output_alias'] ?? null,
+            'porter_alias' => $config['porter_alias'] ?? null,
+        ]);
+        foreach ([self::$porterAlias, self::$mongoAlias] as $alias) {
+            $clash = array_search($alias, $live, true);
+            if ($clash !== false) {
+                return "Test connection '$alias' is also `$clash`. These tests clear what they are "
+                    . 'pointed at, so reserve separate connections for them.';
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Build the `PORT_` tables from Porter's own structure, then fill in one topic and its files.
+     *
+     * @param Storage $storage
+     * @param bool $withGuest Add a comment authored by user 0 (guest).
+     */
+    protected function seed(Storage $storage, bool $withGuest = false): void
+    {
+        $structure = loadData('structure');
+        foreach (['User', 'Role', 'UserRole', 'Category', 'Discussion', 'Comment', 'Media'] as $table) {
+            $storage->prepare($table, $structure[$table]);
+        }
+
+        $db = $storage->getHandle();
+        $db->table('User')->insert([
+            [
+                'UserID' => 1,
+                'Name' => 'Linc',
+                'Email' => 'lincoln@example.com',
+                'Password' => 'hash',
+                'Photo' => 'userpics/avatar.jpg',
+                'DateInserted' => '2020-01-01 00:00:00',
+                'DateLastActive' => '2020-06-01 00:00:00',
+                'SourceAvatarFullPath' => self::SOURCE_UPLOADS . '/userpics/avatar.jpg',
+            ],
+            // Every deleted user shares one name, which NodeBB will not accept.
+            [
+                'UserID' => 2, 'Name' => '[Deleted User]', 'Email' => 'a@example.com',
+                'Password' => 'hash', 'Photo' => null,
+                'DateInserted' => '2020-01-01 00:00:00', 'DateLastActive' => null,
+                'SourceAvatarFullPath' => null,
+            ],
+            [
+                'UserID' => 3, 'Name' => '[Deleted User]', 'Email' => 'b@example.com',
+                'Password' => 'hash', 'Photo' => null,
+                'DateInserted' => '2020-01-01 00:00:00', 'DateLastActive' => null,
+                'SourceAvatarFullPath' => null,
+            ],
+        ]);
+        $db->table('Role')->insert(['RoleID' => 1, 'Name' => 'Members']);
+        $db->table('UserRole')->insert([
+            ['UserID' => 1, 'RoleID' => 1],
+            ['UserID' => self::DELETED_USER_ID, 'RoleID' => 1], // Points at no User row.
+        ]);
+        $db->table('Category')->insert([
+            // Vanilla's root category is a placeholder, not a real forum section.
+            ['CategoryID' => -1, 'Name' => 'Root', 'UrlCode' => 'root', 'Sort' => 0],
+            ['CategoryID' => 1, 'Name' => 'General', 'UrlCode' => 'general', 'Sort' => 1],
+        ]);
+        $db->table('Discussion')->insert([
+            'DiscussionID' => 1,
+            'CategoryID' => 1,
+            'InsertUserID' => 1,
+            'Name' => 'Hello World',
+            'Body' => 'This is the [b]opening[/b] post.',
+            'Format' => 'BBCode',
+            'CountViews' => 7,
+            'DateInserted' => '2020-02-01 00:00:00',
+            'DateLastComment' => '2020-02-02 00:00:00',
+        ]);
+        // CommentIDs deliberately don't start at 1: a fixture where they collide with DiscussionID
+        // can't tell the two ways of resolving the OP's pid apart.
+        $db->table('Comment')->insert([
+            [
+                'CommentID' => self::OP_COMMENT_ID,
+                'DiscussionID' => 1,
+                'InsertUserID' => 1,
+                'Body' => 'This is the [b]opening[/b] post.',
+                'Format' => 'BBCode',
+                'DateInserted' => '2020-02-01 00:00:00',
+            ],
+            [
+                'CommentID' => self::REPLY_COMMENT_ID,
+                'DiscussionID' => 1,
+                'InsertUserID' => 1,
+                'Body' => 'This is a reply.',
+                'Format' => 'BBCode',
+                'DateInserted' => '2020-02-02 00:00:00',
+            ],
+        ]);
+        if ($withGuest) {
+            // Vanilla uses user 0 for guest/authorless content; it must not land on a real account.
+            $db->table('Comment')->insert([
+                'CommentID' => self::GUEST_COMMENT_ID,
+                'DiscussionID' => 1,
+                'InsertUserID' => 0,
+                'Body' => 'Posted by a guest.',
+                'Format' => 'BBCode',
+                'DateInserted' => '2020-02-03 00:00:00',
+            ]);
+        }
+        // One file on the discussion and one (an image) on a comment, so both paths get exercised.
+        $db->table('Media')->insert([
+            [
+                'MediaID' => 1,
+                'Name' => 'report.pdf',
+                'Path' => 'attachments/report.pdf',
+                'Type' => 'application/pdf',
+                'InsertUserID' => 1,
+                'DateInserted' => '2020-02-01 00:00:00',
+                'ForeignID' => 1,
+                'ForeignTable' => 'discussion',
+                'ImageWidth' => null,
+                'ImageHeight' => null,
+                'SourceFullPath' => self::SOURCE_UPLOADS . '/attachments/report.pdf',
+            ],
+            [
+                'MediaID' => 2,
+                'Name' => 'photo.png',
+                'Path' => 'attachments/photo.png',
+                'Type' => 'image/png',
+                'InsertUserID' => 1,
+                'DateInserted' => '2020-02-02 00:00:00',
+                'ForeignID' => self::REPLY_COMMENT_ID,
+                'ForeignTable' => 'Comment',
+                'ImageWidth' => 640,
+                'ImageHeight' => 480,
+                'SourceFullPath' => self::SOURCE_UPLOADS . '/attachments/photo.png',
+            ],
+            [   // No source file, so no file will ever arrive for it.
+                'MediaID' => self::UNTRANSFERABLE_MEDIA_ID,
+                'Name' => 'missing.zip',
+                'Path' => 'attachments/missing.zip',
+                'Type' => 'application/zip',
+                'InsertUserID' => 1,
+                'DateInserted' => '2020-02-03 00:00:00',
+                'ForeignID' => self::REPLY_COMMENT_ID,
+                'ForeignTable' => 'comment',
+                'ImageWidth' => null,
+                'ImageHeight' => null,
+                'SourceFullPath' => null,
+            ],
+        ]);
+    }
+
+    /**
+     * Seed and run a full migration into the document store.
+     *
+     * @param bool $useDiscussionBody Whether the OP arrives on the discussion record.
+     * @return Database
+     */
+    protected function migrate(
+        bool $useDiscussionBody = true,
+        array $installed = [],
+        array $sets = [],
+        bool $withGuest = false
+    ): Database {
+        $porterStorage = Factory::storage(self::$porterAlias, 'PORT_');
+        $this->seed($porterStorage, $withGuest);
+
+        $outputStorage = Factory::storage(self::$mongoAlias);
+        $this->assertInstanceOf(Mongo::class, $outputStorage, 'Expected a document store.');
+
+        // The Target appends to an installed NodeBB and no longer clears anything, so the fixture
+        // is ours to reset. $installed stands in for whatever NodeBB's own setup had written, seeded
+        // through the same object model the Target uses so we never assume the document shape here.
+        $outputStorage->drop(NodeBb::OBJECTS);
+        foreach ($installed as $key => $fields) {
+            $outputStorage->insert(NodeBb::OBJECTS, array_merge(['_key' => $key], $fields));
+        }
+        foreach ($sets as [$key, $value, $score]) {
+            $outputStorage->insert(NodeBb::OBJECTS, ['_key' => $key, 'value' => (string)$value, 'score' => $score]);
+        }
+        $outputStorage->flush();
+
+        $target = Factory::target('NodeBb', $porterStorage, $outputStorage);
+        // Deliberately no enableFileTransfer(): a Vanilla source has none, and attachments must
+        // migrate anyway. The one test that needs a mapping runs filemap() itself.
+        if (!$useDiscussionBody) {
+            $target->skipDiscussionBody();
+        }
+
+        // Buffered because Log::comment() echoes its progress, which PHPUnit counts as risky.
+        ob_start();
+        $target->validate();
+        $target->run();
+        $outputStorage->end(); // Normally called by Controller::doImport().
+        ob_end_clean();
+
+        return $outputStorage->getHandle();
+    }
+
+    /**
+     * Read one object back out of NodeBB's single collection.
+     *
+     * @param Database $db
+     * @param string $key
+     * @return array|null
+     */
+    protected function getObject(Database $db, string $key): ?array
+    {
+        $document = $db->getCollection(NodeBb::OBJECTS)
+            ->findOne(['_key' => $key], ['typeMap' => ['root' => 'array']]);
+        return $document === null ? null : (array)$document;
+    }
+
+    /**
+     * The mapped destination for a seeded attachment, as a NodeBB-relative upload path.
+     *
+     * Restates the rule rather than calling the Target: NodeBB keys uploads on this exact string.
+     *
+     * @param int $mediaID
+     * @return string
+     */
+    protected function getUploadPath(int $mediaID): string
+    {
+        $path = Factory::storage(self::$porterAlias, 'PORT_')->getHandle()
+            ->table('Media')->where('MediaID', $mediaID)->value('Path');
+        $this->assertNotNull($path, "MediaID $mediaID should have a source path.");
+
+        return '/files/' . ltrim((string)$path, '/');
+    }
+
+    public function testWritesUploadHashKeyedOnPath(): void
+    {
+        $db = $this->migrate();
+        $path = $this->getUploadPath(1);
+
+        $upload = $this->getObject($db, 'upload:' . md5($path));
+        $this->assertNotNull($upload, 'Upload should be keyed on the md5 of its relative path.');
+        $this->assertEquals(1, $upload['uid'], 'Upload should record its uploader.');
+    }
+
+    public function testWritesImageDimensionsForImagesOnly(): void
+    {
+        $db = $this->migrate();
+
+        $image = $this->getObject($db, 'upload:' . md5($this->getUploadPath(2)));
+        $this->assertEquals(640, $image['width']);
+        $this->assertEquals(480, $image['height']);
+
+        // NodeBB only stores dimensions for images. @see `Posts.uploads.saveSize()`
+        $document = $this->getObject($db, 'upload:' . md5($this->getUploadPath(1)));
+        $this->assertArrayNotHasKey('width', $document, 'Only images should carry dimensions.');
+    }
+
+    public function testAssociatesUploadWithItsPostAndUploader(): void
+    {
+        $db = $this->migrate();
+        $path = $this->getUploadPath(1);
+
+        // The discussion's file belongs to the OP, whose pid is the topic ID in this mode.
+        $pids = $this->getObject($db, 'upload:' . md5($path) . ':pids');
+        $this->assertEquals('1', $pids['value'], 'Upload should be associated with its post.');
+
+        // A comment's file follows the comment, which is offset past the reused topic IDs.
+        $reply = $this->getObject($db, 'upload:' . md5($this->getUploadPath(2)) . ':pids');
+        $this->assertEquals(
+            (string)(self::REPLY_COMMENT_ID + self::PID_OFFSET),
+            $reply['value'],
+            'A comment attachment should follow its comment.'
+        );
+
+        $uploads = $this->getObject($db, 'uid:1:uploads');
+        $this->assertEquals($path, $uploads['value'], 'Upload should be listed against its uploader.');
+    }
+
+    public function testWritesPostUploadsAsJsonString(): void
+    {
+        $db = $this->migrate();
+
+        // NodeBB stores this as a JSON string, not an array. @see `Posts.uploads.associate()`
+        $post = $this->getObject($db, 'post:1');
+        $this->assertIsString($post['uploads'], 'post.uploads should be a JSON string.');
+        $this->assertEquals([$this->getUploadPath(1)], json_decode($post['uploads']));
+    }
+
+    public function testLinksAttachmentsInPostContent(): void
+    {
+        $db = $this->migrate();
+
+        // Uploads are only visible to readers as links in the content.
+        $post = $this->getObject($db, 'post:1');
+        $this->assertStringContainsString(
+            '<a href="/assets/uploads' . $this->getUploadPath(1) . '">report.pdf</a>',
+            $post['content'],
+            'A non-image attachment should render as a link.'
+        );
+        $this->assertStringContainsString('This is the <b>opening</b> post.', $post['content']);
+
+        $comment = $this->getObject($db, 'post:' . (self::REPLY_COMMENT_ID + self::PID_OFFSET));
+        $this->assertStringContainsString(
+            '<img src="/assets/uploads' . $this->getUploadPath(2) . '" alt="photo.png" />',
+            $comment['content'],
+            'An image attachment should render inline.'
+        );
+    }
+
+    /**
+     * A sorted set's members, as plain strings.
+     *
+     * @param Database $db
+     * @param string $key
+     * @return array
+     */
+    protected function getSetMembers(Database $db, string $key): array
+    {
+        $members = [];
+        $cursor = $db->getCollection(NodeBb::OBJECTS)
+            ->find(['_key' => $key], ['typeMap' => ['root' => 'array']]);
+        foreach ($cursor as $document) {
+            $members[] = (string)((array)$document)['value'];
+        }
+        sort($members);
+
+        return $members;
+    }
+
+    /**
+     * NodeBB renders the OP from `mainPid` and the replies from `tid:{tid}:posts`. A first post in
+     * both shows up twice on the topic page.
+     */
+    public function testFirstPostIsNotAlsoListedAsAReply(): void
+    {
+        $db = $this->migrate();
+        $tid = 1;
+
+        $mainPid = $this->getObject($db, "topic:$tid")['mainPid'];
+        $replies = $this->getSetMembers($db, "tid:$tid:posts");
+
+        $this->assertNotEmpty($replies, 'Replies should be listed for the topic.');
+        $this->assertNotContains((string)$mainPid, $replies, 'The OP must not also list as a reply.');
+        $this->assertEquals(
+            [(string)(self::OP_COMMENT_ID + self::PID_OFFSET), (string)(self::REPLY_COMMENT_ID + self::PID_OFFSET)],
+            $replies,
+            'Both comments are replies when the OP came off the discussion record.'
+        );
+    }
+
+    /**
+     * With the body mode off the OP is one of the comments, so that one has to be held back.
+     *
+     * The body-mode case cannot catch this on its own: there, every comment really is a reply.
+     */
+    public function testFirstPostIsNotAlsoListedAsAReplyWithoutDiscussionBody(): void
+    {
+        $db = $this->migrate(false);
+        $tid = 1;
+
+        $this->assertEquals(
+            self::OP_COMMENT_ID,
+            $this->getObject($db, "topic:$tid")['mainPid'],
+            'The earliest comment is the OP.'
+        );
+        $this->assertEquals(
+            [(string)self::REPLY_COMMENT_ID],
+            $this->getSetMembers($db, "tid:$tid:posts"),
+            'Only the later comment is a reply; the OP renders from mainPid.'
+        );
+    }
+
+    /**
+     * NodeBB indexes {_key,value} unique, so writing one pair twice aborts the whole migration.
+     *
+     * `groups:visible:memberCount` is the trap: the Target seeds a group, then revises its count
+     * in cleanup(), and the install already holds entries for its own system groups.
+     */
+    public function testWritesNoDuplicateSortedSetMembers(): void
+    {
+        $db = $this->migrate(
+            true,
+            ['group:registered-users' => ['name' => 'registered-users', 'memberCount' => 1],
+             'global' => ['nextUid' => 1, 'nextCid' => 1, 'nextTid' => 0, 'nextPid' => 0]],
+            // The install already lists its own groups here; cleanup() must re-score, not re-add.
+            [['groups:visible:memberCount', 'registered-users', 1]]
+        );
+
+        $dupes = $db->getCollection(NodeBb::OBJECTS)->aggregate([
+            ['$match' => ['value' => ['$exists' => true]]],
+            ['$group' => ['_id' => ['k' => '$_key', 'v' => '$value'], 'n' => ['$sum' => 1]]],
+            ['$match' => ['n' => ['$gt' => 1]]],
+            ['$limit' => 5],
+        ])->toArray();
+        $this->assertEmpty(
+            array_map(fn($d) => (array)((array)$d)['_id'], $dupes),
+            'A repeated {_key,value} breaks the unique index NodeBB builds on boot.'
+        );
+    }
+
+    /**
+     * Guest-authored content (Vanilla user 0) must not be attributed to a real account.
+     *
+     * With an install present the uid offset is non-zero, so a naive `0 + offset` lands the guest's
+     * posts on whichever user occupies that uid — the admin. Guest stays uid 0 in NodeBB.
+     */
+    public function testAttributesGuestContentToGuestNotAdmin(): void
+    {
+        // Install admin at uid 1, so the offset is 1 and the bug would map guest -> uid 1.
+        $db = $this->migrate(
+            true,
+            ['user:1' => ['uid' => 1, 'username' => 'admin'],
+             'global' => ['nextUid' => 1, 'nextCid' => 1, 'nextTid' => 0, 'nextPid' => 0]],
+            [],
+            true
+        );
+
+        // The guest comment's post is authored by guest (uid 0), not the admin.
+        $guestPid = self::GUEST_COMMENT_ID + self::PID_OFFSET;
+        $this->assertEquals(0, $this->getObject($db, "post:$guestPid")['uid'], 'Guest post stays uid 0.');
+
+        // The admin must own no migrated content, and its counts must be untouched.
+        $adminPosts = $db->getCollection(NodeBb::OBJECTS)
+            ->countDocuments(['_key' => ['$regex' => '^post:'], 'uid' => 1]);
+        $this->assertEquals(0, $adminPosts, 'No migrated post should be attributed to the admin.');
+        $this->assertArrayNotHasKey('postcount', $this->getObject($db, 'user:1'), 'Admin counts stay untouched.');
+    }
+
+    /**
+     * Vanilla's root category is a placeholder, and every other Target drops it.
+     */
+    public function testIgnoresTheVanillaRootCategory(): void
+    {
+        $db = $this->migrate();
+
+        $this->assertNotNull($this->getObject($db, 'category:1'), 'A real category still migrates.');
+        $this->assertEquals(
+            ['1'],
+            $this->getSetMembers($db, 'categories:cid'),
+            'Only the real category should be listed.'
+        );
+    }
+
+    /**
+     * A role assignment for a user who no longer exists would add a dead uid to a group.
+     */
+    public function testPrunesOrphanedRoleAssignments(): void
+    {
+        $db = $this->migrate();
+
+        $this->assertEquals(
+            ['1'],
+            $this->getSetMembers($db, 'group:Members:members'),
+            'A membership for a missing user should be pruned.'
+        );
+    }
+
+    /**
+     * NodeBB requires unique usernames, and every deleted user arrives sharing one.
+     */
+    public function testRenamesDuplicateDeletedUsers(): void
+    {
+        $db = $this->migrate();
+
+        $this->assertEquals('deleted_user_2', $this->getObject($db, 'user:2')['username']);
+        $this->assertEquals('deleted_user_3', $this->getObject($db, 'user:3')['username']);
+
+        // Both must be reachable; a shared name would leave the second with no lookup entry.
+        $this->assertEqualsCanonicalizing(
+            ['Linc', 'deleted_user_2', 'deleted_user_3'],
+            $this->getSetMembers($db, 'username:uid'),
+            'Every migrated user needs a username lookup.'
+        );
+    }
+
+    /**
+     * Counts NodeBB shows but never recalculates on its own.
+     */
+    public function testFinalizesCounts(): void
+    {
+        $db = $this->migrate();
+
+        // 1 synthesized OP + 2 comments.
+        $this->assertEquals(3, $this->getObject($db, 'topic:1')['postcount'], 'topic.postcount');
+        $this->assertEquals(1, $this->getObject($db, 'category:1')['topic_count'], 'category.topic_count');
+        $this->assertEquals(3, $this->getObject($db, 'category:1')['post_count'], 'category.post_count');
+
+        $user = $this->getObject($db, 'user:1');
+        $this->assertEquals(1, $user['topiccount'], 'user.topiccount');
+        $this->assertEquals(3, $user['postcount'], 'user.postcount');
+    }
+
+    /**
+     * With the body mode off the OP is already a comment, so counting it again inflates everything.
+     */
+    public function testCountsDoNotDoubleCountTheOpAsAComment(): void
+    {
+        $db = $this->migrate(false);
+
+        $this->assertEquals(2, $this->getObject($db, 'topic:1')['postcount'], 'topic.postcount');
+        $this->assertEquals(2, $this->getObject($db, 'category:1')['post_count'], 'category.post_count');
+        $this->assertEquals(2, $this->getObject($db, 'user:1')['postcount'], 'user.postcount');
+    }
+
+    /**
+     * NodeBB assigns new IDs from these, so a stale counter overwrites migrated records.
+     */
+    public function testAdvancesGlobalCountersPastMigratedIds(): void
+    {
+        $db = $this->migrate();
+        $global = $this->getObject($db, 'global');
+
+        $this->assertGreaterThan(
+            (int)$this->getObject($db, 'topic:1')['mainPid'],
+            (int)$global['nextPid'] + 1,
+            'The next pid NodeBB assigns must clear every migrated post.'
+        );
+        $highestPid = self::REPLY_COMMENT_ID + self::PID_OFFSET;
+        $this->assertEquals($highestPid, $global['nextPid'], 'nextPid');
+        $this->assertEquals(3, $global['nextUid'], 'nextUid');
+        $this->assertEquals(1, $global['nextTid'], 'nextTid');
+        $this->assertEquals(1, $global['topicCount'], 'topicCount');
+        $this->assertEquals(3, $global['postCount'], 'postCount');
+    }
+
+    /**
+     * Every NodeBB user must be in `registered-users` or they have no privileges anywhere.
+     */
+    public function testAddsUsersToRegisteredUsers(): void
+    {
+        $db = $this->migrate();
+
+        $this->assertEquals(
+            ['1', '2', '3'],
+            $this->getSetMembers($db, 'group:registered-users:members'),
+            'Migrated users must join registered-users.'
+        );
+    }
+
+    /**
+     * The Target appends to an installed NodeBB; wiping its config or admin breaks the forum.
+     */
+    public function testPreservesAnExistingInstall(): void
+    {
+        // Stands in for what NodeBB's own setup wrote: config, the admin, a default category.
+        $db = $this->migrate(true, [
+            'config' => ['title' => 'Existing Forum'],
+            'user:1' => ['uid' => 1, 'username' => 'admin'],
+            'category:1' => ['cid' => 1, 'name' => 'Announcements'],
+            'group:registered-users' => ['name' => 'registered-users', 'memberCount' => 1],
+            // As NodeBB writes them: the highest id already assigned.
+            'global' => ['nextUid' => 1, 'nextCid' => 1, 'nextTid' => 0, 'nextPid' => 0],
+        ]);
+
+        $this->assertEquals('Existing Forum', $this->getObject($db, 'config')['title'], 'Config survives.');
+        $this->assertEquals('admin', $this->getObject($db, 'user:1')['username'], 'The admin survives.');
+        $this->assertEquals('Announcements', $this->getObject($db, 'category:1')['name'], 'Its category survives.');
+
+        // Migrated records start above the IDs the install had already assigned.
+        $this->assertEquals('Linc', $this->getObject($db, 'user:2')['username'], 'Migrated user is offset.');
+        $this->assertEquals('General', $this->getObject($db, 'category:2')['name'], 'Migrated category is offset.');
+        $this->assertEquals(2, $this->getObject($db, 'topic:1')['cid'], 'Topic points at the offset category.');
+        $this->assertEquals(2, $this->getObject($db, 'topic:1')['uid'], 'Topic points at the offset user.');
+
+        // The install's own records must be untouched by the ones written around them.
+        $this->assertEquals(1, $this->getObject($db, 'user:1')['uid'], 'The admin keeps uid 1.');
+
+        // The install's own member is still counted alongside ours.
+        $this->assertEquals(
+            4,
+            $this->getObject($db, 'group:registered-users')['memberCount'],
+            'memberCount adds to the install.'
+        );
+    }
+
+    /**
+     * Duplicate or reserved group names break NodeBB's unique index, which stops it booting.
+     */
+    public function testSkipsDuplicateAndReservedGroupNames(): void
+    {
+        $storage = Factory::storage(self::$porterAlias, 'PORT_');
+        $db = $this->migrate();
+
+        // Two roles sharing a name, plus one shadowing a NodeBB system group.
+        $storage->getHandle()->table('Role')->insert([
+            ['RoleID' => 2, 'Name' => 'Members'],
+            ['RoleID' => 3, 'Name' => 'administrators'],
+        ]);
+        $db = $this->migrate();
+
+        $groups = $this->getSetMembers($db, 'groups:createtime');
+        $this->assertEquals(['Members'], $groups, 'Only the first non-reserved role becomes a group.');
+
+        // A second `{_key,value}` for one group is what makes NodeBB's index build fail.
+        $duplicates = $db->getCollection(NodeBb::OBJECTS)->countDocuments(['_key' => 'group:Members']);
+        $this->assertEquals(1, $duplicates, 'A group must be written exactly once.');
+    }
+
+    /**
+     * Attachment records do not depend on the files being moved, same as every other Target.
+     *
+     * A file transfer is a separate step the operator may or may not run; Flarum and Agorakit both
+     * import their attachment rows from `Media.Path` regardless. Gating on it here would mean a
+     * Vanilla source (which has no file transfer support) migrated no attachments at all.
+     */
+    public function testMigratesAttachmentsWithoutAFileTransfer(): void
+    {
+        $db = $this->migrate();
+
+        $this->assertNull(
+            Factory::storage(self::$porterAlias, 'PORT_')->getHandle()->table('Media')
+                ->where('MediaID', self::UNTRANSFERABLE_MEDIA_ID)->value('TargetFullPath'),
+            'Nothing should have been mapped without a file transfer.'
+        );
+
+        // Every attachment on a migrated post still becomes an upload.
+        $uploads = $db->getCollection(NodeBb::OBJECTS)
+            ->countDocuments(['_key' => ['$regex' => '^upload:[0-9a-f]{32}$']]);
+        $this->assertEquals(3, $uploads, 'All three attachments should become uploads.');
+
+        $reply = $this->getObject($db, 'post:' . (self::REPLY_COMMENT_ID + self::PID_OFFSET));
+        $this->assertStringContainsString('missing.zip', $reply['content'], 'Its link is still written.');
+    }
+
+    /**
+     * The upload path has to match where a file transfer would put the file, or links break.
+     */
+    public function testUploadPathMatchesTheFileTransferDestination(): void
+    {
+        $storage = Factory::storage(self::$porterAlias, 'PORT_');
+        $this->migrate();
+
+        // Run the mapping the file transfer would use.
+        $target = Factory::target('NodeBb', $storage, Factory::storage(self::$mongoAlias));
+        $target->enableFileTransfer();
+        ob_start();
+        new ReflectionMethod($target, 'filemap')->invoke($target);
+        ob_end_clean();
+
+        $mapped = $storage->getHandle()->table('Media')->where('MediaID', 1)->value('TargetFullPath');
+        $this->assertStringEndsWith(
+            $this->getUploadPath(1),
+            (string)$mapped,
+            'The copied file must land at the path the upload record points to.'
+        );
+    }
+
+    /**
+     * With the body mode off the OP is a comment, so attachments have to follow it there.
+     */
+    public function testResolvesAttachmentPidWithoutDiscussionBody(): void
+    {
+        $db = $this->migrate(false);
+
+        // Nothing synthesizes a post at the topic ID, and comment pids pass through unoffset.
+        $this->assertNull($this->getObject($db, 'post:1'), 'No post should reuse the topic ID in this mode.');
+        $this->assertEquals(
+            self::OP_COMMENT_ID,
+            $this->getObject($db, 'topic:1')['mainPid'],
+            'mainPid should be the earliest comment.'
+        );
+
+        // The discussion's file has to land on that comment, not on the discussion ID.
+        $op = $this->getObject($db, 'post:' . self::OP_COMMENT_ID);
+        $this->assertEquals(
+            [$this->getUploadPath(1)],
+            json_decode($op['uploads']),
+            "A discussion attachment should resolve onto the OP's comment."
+        );
+
+        $reply = $this->getObject($db, 'post:' . self::REPLY_COMMENT_ID);
+        $this->assertEqualsCanonicalizing(
+            [$this->getUploadPath(2), $this->getUploadPath(self::UNTRANSFERABLE_MEDIA_ID)],
+            json_decode($reply['uploads']),
+            'Comment attachments should stay on their comment.'
+        );
+    }
+}

--- a/tests/unit/ParserTest.php
+++ b/tests/unit/ParserTest.php
@@ -94,4 +94,49 @@ final class ParserTest extends TestCase
         $expected = '<div class="post-text-align-center"><br><br>&nbsp;Administrateur<br>version </div>';
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * @dataProvider getToHtmlTests()
+     * @covers \Porter\Formatter::toHtml
+     */
+    public function testToHtml(?string $format, ?string $text, string $expected): void
+    {
+        $this->assertEquals($expected, Formatter::instance()->toHtml($format, $text));
+    }
+
+    public function getToHtmlTests(): array
+    {
+        return [
+            [   // BBCode is rendered, not left as markup.
+                'BBCode',
+                'Hello [b]world[/b]',
+                'Hello <b>world</b>',
+            ],
+            [   // Format matching is case-insensitive.
+                'bbcode',
+                'Hello [b]world[/b]',
+                'Hello <b>world</b>',
+            ],
+            [   // Markdown is rendered to HTML.
+                'Markdown',
+                'Hello **world**',
+                '<p>Hello <strong>world</strong></p>',
+            ],
+            [   // Plain text is literal, so its markup gets escaped.
+                'Text',
+                "<b>not bold</b>\nsecond line",
+                "&lt;b&gt;not bold&lt;/b&gt;<br />\nsecond line",
+            ],
+            [   // An unknown format falls through to text.
+                null,
+                'Hello',
+                'Hello',
+            ],
+            [   // Null content is allowed.
+                'Html',
+                null,
+                '',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
_This feature set is funded through [Open Social Fund](https://nlnet.nl/opensocial), a fund established by [NLnet](https://nlnet.nl/)._

- [x] a. Engine support for MongoDB 
- [x] b. Data mapping for NodeBB as Target
- [x] c. File transfers for NodeBB as Target
- [x] d. NodeBB 'Postscript' (missing derived data)
- [x] e. NodeBB support documentation